### PR TITLE
these raw instructions are unsafe

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -3,12 +3,10 @@
 macro_rules! instruction {
     ($fnname:ident, $asm:expr) => (
         #[inline]
-        pub fn $fnname() {
+        pub unsafe fn $fnname() {
             match () {
                 #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
-                () => unsafe {
-                    asm!($asm :::: "volatile");
-                },
+                () => asm!($asm :::: "volatile"),
                 #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
                 () => {}
             }


### PR DESCRIPTION
`wfi` is safe, but the rest are not. Let's make them all unsafe until we have a better idea — the return types are wrong anyhow.
