### PR TITLE
Remove ecall and *ret instructions from riscv::asm

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -16,9 +16,5 @@ macro_rules! instruction {
 
 
 /// Priviledged ISA Instructions
-instruction!(ecall, "ecall");
 instruction!(ebreak, "ebreak");
-instruction!(uret, "uret");
-instruction!(sret, "sret");
-instruction!(mret, "mret");
 instruction!(wfi, "wfi");


### PR DESCRIPTION
* *ret instructions should not be used directly in Rust code, they should be used in handlers, written in asm ([example](https://github.com/rust-embedded/riscv-rt/blob/273f0d4f70418a7602678632dcc78dbe24208fe2/src/lib.rs#L294-L340)).
* ecall function should be wrapped into something like syscall(), which should be declared in another platform-specific crate.