### PR TITLE
Do not panic on unknown trap mode.

### DIFF
--- a/src/register/mtvec.rs
+++ b/src/register/mtvec.rs
@@ -25,12 +25,12 @@ impl Mtvec {
     }
 
     /// Returns the trap-vector mode
-    pub fn trap_mode(&self) -> TrapMode {
+    pub fn trap_mode(&self) -> Option<TrapMode> {
         let mode = self.bits & 0b11;
         match mode {
-            0 => TrapMode::Direct,
-            1 => TrapMode::Vectored,
-            _ => unimplemented!(),
+            0 => Some(TrapMode::Direct),
+            1 => Some(TrapMode::Vectored),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Some vendors (eg Nuclei) use reserved bits for they own interrupt handling.