### PR TITLE
Fix {S,U}tvec::trap_mode() functions to match Mtvec::trap_mode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- `Mtvec::trap_mode()` not returns `Option<TrapMode>` (breaking change)
+- `Mtvec::trap_mode()`, `Stvec::trap_mode()` and `Utvec::trap_mode()` functions now return `Option<TrapMode>` (breaking change)
 - Updated Minimum Supported Rust Version to 1.42.0
 - Use `llvm_asm!` instead of `asm!`
 

--- a/src/register/stvec.rs
+++ b/src/register/stvec.rs
@@ -20,12 +20,12 @@ impl Stvec {
     }
 
     /// Returns the trap-vector mode
-    pub fn trap_mode(&self) -> TrapMode {
+    pub fn trap_mode(&self) -> Option<TrapMode> {
         let mode = self.bits & 0b11;
         match mode {
-            0 => TrapMode::Direct,
-            1 => TrapMode::Vectored,
-            _ => unimplemented!(),
+            0 => Some(TrapMode::Direct),
+            1 => Some(TrapMode::Vectored),
+            _ => None,
         }
     }
 }

--- a/src/register/utvec.rs
+++ b/src/register/utvec.rs
@@ -20,12 +20,12 @@ impl Utvec {
     }
 
     /// Returns the trap-vector mode
-    pub fn trap_mode(&self) -> TrapMode {
+    pub fn trap_mode(&self) -> Option<TrapMode> {
         let mode = self.bits & 0b11;
         match mode {
-            0 => TrapMode::Direct,
-            1 => TrapMode::Vectored,
-            _ => unimplemented!(),
+            0 => Some(TrapMode::Direct),
+            1 => Some(TrapMode::Vectored),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
See also: https://github.com/rust-embedded/riscv/pull/50#issuecomment-647012575