### PR TITLE
Fix unescaped "[]"s in doc comment

### DIFF
--- a/src/register/mcounteren.rs
+++ b/src/register/mcounteren.rs
@@ -9,25 +9,25 @@ pub struct Mcounteren {
 }
 
 impl Mcounteren {
-    /// Supervisor "cycle[h]" Enable
+    /// Supervisor "cycle\[h\]" Enable
     #[inline]
     pub fn cy(&self) -> bool {
         self.bits.get_bit(0)
     }
 
-    /// Supervisor "time[h]" Enable
+    /// Supervisor "time\[h\]" Enable
     #[inline]
     pub fn tm(&self) -> bool {
         self.bits.get_bit(1)
     }
 
-    /// Supervisor "instret[h]" Enable
+    /// Supervisor "instret\[h\]" Enable
     #[inline]
     pub fn ir(&self) -> bool {
         self.bits.get_bit(2)
     }
 
-    /// Supervisor "hpm[x]" Enable (bits 3-31)
+    /// Supervisor "hpm\[x\]" Enable (bits 3-31)
     #[inline]
     pub fn hpm(&self, index: usize) -> bool {
         assert!(3 <= index && index < 32);

--- a/src/register/scounteren.rs
+++ b/src/register/scounteren.rs
@@ -9,25 +9,25 @@ pub struct Scounteren {
 }
 
 impl Scounteren {
-    /// User "cycle[h]" Enable
+    /// User "cycle\[h\]" Enable
     #[inline]
     pub fn cy(&self) -> bool {
         self.bits.get_bit(0)
     }
 
-    /// User "time[h]" Enable
+    /// User "time\[h\]" Enable
     #[inline]
     pub fn tm(&self) -> bool {
         self.bits.get_bit(1)
     }
 
-    /// User "instret[h]" Enable
+    /// User "instret\[h]\" Enable
     #[inline]
     pub fn ir(&self) -> bool {
         self.bits.get_bit(2)
     }
 
-    /// User "hpm[x]" Enable (bits 3-31)
+    /// User "hpm\[x\]" Enable (bits 3-31)
     #[inline]
     pub fn hpm(&self, index: usize) -> bool {
         assert!(3 <= index && index < 32);


### PR DESCRIPTION
When running `cargo doc` on this crate and crates depends on this crate, cargo will always raise `unresolved link` warnings for those `[h]` and `[x]`, which is annoying.

This pr escaped the `[` and `]` in these code to silence these warning.