### PR TITLE
Fix link to RISC-V team in wg repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Conduct][CoC], the maintainer of this crate, the [RISC-V team][team], promises
 to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md
-[team]: https://github.com/rust-embedded/wg#the-riscv-team
+[team]: https://github.com/rust-embedded/wg#the-risc-v-team


### PR DESCRIPTION
Fixes link to properly direct to heading in wg repo README.md.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>