### PR TITLE
Fix register configuration and documents

### DIFF
--- a/src/register/satp.rs
+++ b/src/register/satp.rs
@@ -1,6 +1,5 @@
 //! satp register
 
-#[cfg(riscv)]
 use bit_field::BitField;
 
 /// satp register
@@ -18,7 +17,7 @@ impl Satp {
 
     /// Current address-translation scheme
     #[inline]
-    #[cfg(riscv32)]
+    #[cfg(target_pointer_width = "32")]
     pub fn mode(&self) -> Mode {
         match self.bits.get_bit(31) {
             false => Mode::Bare,
@@ -28,7 +27,7 @@ impl Satp {
 
     /// Current address-translation scheme
     #[inline]
-    #[cfg(riscv64)]
+    #[cfg(target_pointer_width = "64")]
     pub fn mode(&self) -> Mode {
         match self.bits.get_bits(60..64) {
             0 => Mode::Bare,
@@ -42,55 +41,65 @@ impl Satp {
 
     /// Address space identifier
     #[inline]
-    #[cfg(riscv32)]
+    #[cfg(target_pointer_width = "32")]
     pub fn asid(&self) -> usize {
         self.bits.get_bits(22..31)
     }
 
     /// Address space identifier
     #[inline]
-    #[cfg(riscv64)]
+    #[cfg(target_pointer_width = "64")]
     pub fn asid(&self) -> usize {
         self.bits.get_bits(44..60)
     }
 
     /// Physical page number
     #[inline]
-    #[cfg(riscv32)]
+    #[cfg(target_pointer_width = "32")]
     pub fn ppn(&self) -> usize {
         self.bits.get_bits(0..22)
     }
 
     /// Physical page number
     #[inline]
-    #[cfg(riscv64)]
+    #[cfg(target_pointer_width = "64")]
     pub fn ppn(&self) -> usize {
         self.bits.get_bits(0..44)
     }
 }
 
-#[cfg(riscv32)]
+/// 32-bit satp mode
+#[cfg(target_pointer_width = "32")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Mode {
+    /// No translation or protection
     Bare = 0,
+    /// Page-based 32-bit virtual addressing
     Sv32 = 1,
 }
 
-#[cfg(riscv64)]
+/// 64-bit satp mode
+#[cfg(target_pointer_width = "64")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Mode {
+    /// No translation or protection
     Bare = 0,
+    /// Page-based 32-bit virtual addressing
     Sv39 = 8,
+    /// Page-based 48-bit virtual addressing
     Sv48 = 9,
+    /// Page-based 57-bit virtual addressing
     Sv57 = 10,
+    /// Page-based 64-bit virtual addressing
     Sv64 = 11,
 }
 
 read_csr_as!(Satp, 0x180, __read_satp);
 write_csr_as_usize!(0x180, __write_satp);
 
+/// Sets the register to corresponding page table mode, physical page number and address space id.
 #[inline]
-#[cfg(riscv32)]
+#[cfg(target_pointer_width = "32")]
 pub unsafe fn set(mode: Mode, asid: usize, ppn: usize) {
     let mut bits = 0usize;
     bits.set_bits(31..32, mode as usize);
@@ -99,8 +108,9 @@ pub unsafe fn set(mode: Mode, asid: usize, ppn: usize) {
     _write(bits);
 }
 
+/// Sets the register to corresponding page table mode, physical page number and address space id.
 #[inline]
-#[cfg(riscv64)]
+#[cfg(target_pointer_width = "64")]
 pub unsafe fn set(mode: Mode, asid: usize, ppn: usize) {
     let mut bits = 0usize;
     bits.set_bits(60..64, mode as usize);

--- a/src/register/satp.rs
+++ b/src/register/satp.rs
@@ -84,7 +84,7 @@ pub enum Mode {
 pub enum Mode {
     /// No translation or protection
     Bare = 0,
-    /// Page-based 32-bit virtual addressing
+    /// Page-based 39-bit virtual addressing
     Sv39 = 8,
     /// Page-based 48-bit virtual addressing
     Sv48 = 9,

--- a/src/register/scause.rs
+++ b/src/register/scause.rs
@@ -118,11 +118,13 @@ read_csr_as!(Scause, 0x142, __read_scause);
 write_csr!(0x142, __write_scause);
 
 /// Writes the CSR
+#[inline]
 pub unsafe fn write(bits: usize) {
     _write(bits)
 }
 
 /// Set supervisor cause register to corresponding cause.
+#[inline]
 pub unsafe fn set(cause: Trap) {
     let bits = match cause {
         Trap::Interrupt(i) => match i {

--- a/src/register/stval.rs
+++ b/src/register/stval.rs
@@ -4,6 +4,7 @@ read_csr_as_usize!(0x143, __read_stval);
 write_csr!(0x143, __write_stval);
 
 /// Writes the CSR
+#[inline]
 pub unsafe fn write(bits: usize) {
     _write(bits)
 }

--- a/src/register/ucause.rs
+++ b/src/register/ucause.rs
@@ -18,6 +18,7 @@ read_csr_as!(Ucause, 0x042, __read_ucause);
 write_csr!(0x042, __write_ucause);
 
 /// Writes the CSR
+#[inline]
 pub unsafe fn write(bits: usize) {
     _write(bits)
 }

--- a/src/register/utval.rs
+++ b/src/register/utval.rs
@@ -4,6 +4,7 @@ read_csr_as_usize!(0x043, __read_utval);
 write_csr!(0x043, __write_utval);
 
 /// Writes the CSR
+#[inline]
 pub unsafe fn write(bits: usize) {
     _write(bits)
 }


### PR DESCRIPTION
This pull request contains:

1. Use `#[cfg(target_pointer_width = "32")]` other than `#[cfg(riscv32)]` to provide support on IDE lint and cargo doc outputs
2. Add `#[inline]` on most of `set` and `write` functions
