### PR TITLE
Bug fix for interrupt bit in `scause::set`

### DIFF
--- a/src/register/scause.rs
+++ b/src/register/scause.rs
@@ -127,15 +127,17 @@ pub unsafe fn write(bits: usize) {
 #[inline]
 pub unsafe fn set(cause: Trap) {
     let bits = match cause {
-        Trap::Interrupt(i) => (match i {
-            Interrupt::UserSoft => 0,
-            Interrupt::SupervisorSoft => 1,
-            Interrupt::UserTimer => 4,
-            Interrupt::SupervisorTimer => 5,
-            Interrupt::UserExternal => 8,
-            Interrupt::SupervisorExternal => 9,
-            Interrupt::Unknown => panic!("unknown interrupt"),
-        } | (1 << (size_of::<usize>() * 8 - 1))), // interrupt bit is 1
+        Trap::Interrupt(i) => {
+            (match i {
+                Interrupt::UserSoft => 0,
+                Interrupt::SupervisorSoft => 1,
+                Interrupt::UserTimer => 4,
+                Interrupt::SupervisorTimer => 5,
+                Interrupt::UserExternal => 8,
+                Interrupt::SupervisorExternal => 9,
+                Interrupt::Unknown => panic!("unknown interrupt"),
+            } | (1 << (size_of::<usize>() * 8 - 1)))
+        } // interrupt bit is 1
         Trap::Exception(e) => match e {
             Exception::InstructionMisaligned => 0,
             Exception::InstructionFault => 1,
@@ -149,7 +151,7 @@ pub unsafe fn set(cause: Trap) {
             Exception::LoadPageFault => 13,
             Exception::StorePageFault => 15,
             Exception::Unknown => panic!("unknown exception"),
-        } // interrupt bit is 0
+        }, // interrupt bit is 0
     };
     _write(bits);
 }

--- a/src/register/scause.rs
+++ b/src/register/scause.rs
@@ -127,7 +127,7 @@ pub unsafe fn write(bits: usize) {
 #[inline]
 pub unsafe fn set(cause: Trap) {
     let bits = match cause {
-        Trap::Interrupt(i) => match i {
+        Trap::Interrupt(i) => (match i {
             Interrupt::UserSoft => 0,
             Interrupt::SupervisorSoft => 1,
             Interrupt::UserTimer => 4,
@@ -135,23 +135,21 @@ pub unsafe fn set(cause: Trap) {
             Interrupt::UserExternal => 8,
             Interrupt::SupervisorExternal => 9,
             Interrupt::Unknown => panic!("unknown interrupt"),
-        },
-        Trap::Exception(e) => {
-            (match e {
-                Exception::InstructionMisaligned => 0,
-                Exception::InstructionFault => 1,
-                Exception::IllegalInstruction => 2,
-                Exception::Breakpoint => 3,
-                Exception::LoadFault => 5,
-                Exception::StoreMisaligned => 6,
-                Exception::StoreFault => 7,
-                Exception::UserEnvCall => 8,
-                Exception::InstructionPageFault => 12,
-                Exception::LoadPageFault => 13,
-                Exception::StorePageFault => 15,
-                Exception::Unknown => panic!("unknown exception"),
-            } | (1 << (size_of::<usize>() * 8 - 1)))
-        }
+        } | (1 << (size_of::<usize>() * 8 - 1))), // interrupt bit is 1
+        Trap::Exception(e) => match e {
+            Exception::InstructionMisaligned => 0,
+            Exception::InstructionFault => 1,
+            Exception::IllegalInstruction => 2,
+            Exception::Breakpoint => 3,
+            Exception::LoadFault => 5,
+            Exception::StoreMisaligned => 6,
+            Exception::StoreFault => 7,
+            Exception::UserEnvCall => 8,
+            Exception::InstructionPageFault => 12,
+            Exception::LoadPageFault => 13,
+            Exception::StorePageFault => 15,
+            Exception::Unknown => panic!("unknown exception"),
+        } // interrupt bit is 0
     };
     _write(bits);
 }


### PR DESCRIPTION
This pull request includes a bug fix. On RISC-V's cause register, first bit means is this cause an interrupt. The code before made a mistake to or an one bit when exception. After this fix, it correctly or an one bit when interrupt.

Related to https://github.com/luojia65/rustsbi/issues/10. Thank you @wyfcyx