### PR TITLE
Add docs.rs document build metadata for build targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Build targets on `docs.rs` are now RISC-V targets other than default ones
+
 ## [v0.6.0] - 2020-06-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ description = "Low level access to RISC-V processors"
 keywords = ["riscv", "register", "peripheral"]
 license = "ISC"
 
+[package.metadata.docs.rs]
+default-target = "riscv64imac-unknown-none-elf"
+targets = [
+    "riscv32i-unknown-none-elf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf",
+    "riscv64imac-unknown-none-elf", "riscv64gc-unknown-none-elf",
+]
+
 [dependencies]
 bare-metal = "0.2.5"
 bit_field = "0.10.0"


### PR DESCRIPTION
This pull request changes build targets when build documents on `docs.rs`, it will show RISC-V targets other than default x86 targets.

Before:

![image](https://user-images.githubusercontent.com/40385009/116803431-2add2e00-ab4a-11eb-87ea-b1cd204299d2.png)

After (take `rustsbi` crate as example): 

![image](https://user-images.githubusercontent.com/40385009/116803427-2284f300-ab4a-11eb-8974-24126cbc4310.png)

