### PR TITLE
add a bunch of setter for mstatus

### DIFF
--- a/src/register/mstatus.rs
+++ b/src/register/mstatus.rs
@@ -63,7 +63,7 @@ impl Mstatus {
         self.bits.set_bit(0, value);
     }
 
-    /// Supervisor Interrupt Enable
+    /// Set bit for Supervisor Interrupt Enable
     #[inline]
     pub fn bitset_sie(&mut self, value: bool) {
         self.bits.set_bit(1, value);

--- a/src/register/mstatus.rs
+++ b/src/register/mstatus.rs
@@ -59,6 +59,154 @@ pub enum SPP {
 impl Mstatus {
     /// User Interrupt Enable
     #[inline]
+    pub fn set_uie(&mut self, value: bool) {
+        self.bits.set_bit(0, value);
+    }
+
+    /// Supervisor Interrupt Enable
+    #[inline]
+    pub fn set_sie(&mut self, value: bool) {
+        self.bits.set_bit(1, value);
+    }
+
+    /// Machine Interrupt Enable
+    #[inline]
+    pub fn set_mie(&mut self, value: bool) {
+        self.bits.set_bit(3, value);
+    }
+
+    /// User Previous Interrupt Enable
+    #[inline]
+    pub fn set_upie(&mut self, value: bool) {
+        self.bits.set_bit(4, value);
+    }
+
+    /// Supervisor Previous Interrupt Enable
+    #[inline]
+    pub fn set_spie(&mut self, value: bool) {
+        self.bits.set_bit(5, value);
+    }
+
+    /// Machine Previous Interrupt Enable
+    #[inline]
+    pub fn set_mpie(&mut self, value: bool) {
+        self.bits.set_bit(7, value);
+    }
+
+    /// Supervisor Previous Privilege Mode
+    #[inline]
+    pub fn set_spp(&mut self, spp: SPP) {
+        match spp {
+            SPP::Supervisor => self.bits.set_bit(8, true),
+            SPP::User => self.bits.set_bit(8, false),
+        };
+    }
+
+    /// Machine Previous Privilege Mode
+    #[inline]
+    pub fn set_mpp(&mut self, mpp: MPP) {
+        match mpp {
+            MPP::User => self.bits.set_bits(11..13, 0b00),
+            MPP::Supervisor => self.bits.set_bits(11..13, 0b01),
+            MPP::Machine => self.bits.set_bits(11..13, 0b11),
+        };
+    }
+
+    /// Floating-point extension state
+    ///
+    /// Encodes the status of the floating-point unit,
+    /// including the CSR `fcsr` and floating-point data registers `f0–f31`.
+    #[inline]
+    pub fn set_fs(&mut self, fs: FS) {
+        match fs {
+            FS::Off => self.bits.set_bits(13..15, 0b00),
+            FS::Initial => self.bits.set_bits(13..15, 0b01),
+            FS::Clean => self.bits.set_bits(13..15, 0b10),
+            FS::Dirty => self.bits.set_bits(13..15, 0b11),
+        };
+    }
+
+    /// Additional extension state
+    ///
+    /// Encodes the status of additional user-mode extensions and associated state.
+    #[inline]
+    pub fn set_xs(&mut self, xs: XS) {
+        match xs {
+            XS::AllOff => self.bits.set_bits(15..17, 0b00),
+            XS::NoneDirtyOrClean => self.bits.set_bits(15..17, 0b01),
+            XS::NoneDirtySomeClean => self.bits.set_bits(15..17, 0b10),
+            XS::SomeDirty => self.bits.set_bits(15..17, 0b11),
+        };
+    }
+
+    /// Modify Memory PRiVilege
+    #[inline]
+    pub fn set_mprv(&mut self, value: bool) {
+        self.bits.set_bit(17, value);
+    }
+
+    /// Permit Supervisor User Memory access
+    #[inline]
+    pub fn set_sum(&mut self, value: bool) {
+        self.bits.set_bit(18, value);
+    }
+
+    /// Make eXecutable Readable
+    #[inline]
+    pub fn set_mxr(&mut self, value: bool) {
+        self.bits.set_bit(19, value);
+    }
+
+    /// Trap Virtual Memory
+    ///
+    /// If this bit is set, reads or writes to `satp` CSR or execute `sfence.vma`
+    /// instruction when in S-mode will raise an illegal instruction exception.
+    ///
+    /// TVM is hard-wired to 0 when S-mode is not supported.
+    #[inline]
+    pub fn set_tvm(&mut self, value: bool) {
+        self.bits.set_bit(20, value);
+    }
+
+    /// Timeout Wait
+    ///
+    /// Indicates that if WFI instruction should be intercepted.
+    ///
+    /// If this bit is set, when WFI is executed in S-mode, and it does not complete
+    /// within an implementation specific, bounded time limit, the WFI instruction will cause
+    /// an illegal instruction trap; or could always cause trap then the time limit is zero.
+    ///
+    /// TW is hard-wired to 0 when S-mode is not supported.
+    #[inline]
+    pub fn set_tw(&mut self, value: bool) {
+        self.bits.set_bit(21, value);
+    }
+
+    /// Trap SRET
+    ///
+    /// Indicates that if SRET instruction should be trapped to raise illegal
+    /// instruction exception.
+    ///
+    /// If S-mode is not supported, TSR bit is hard-wired to 0.
+    #[inline]
+    pub fn set_tsr(&mut self, value: bool) {
+        self.bits.set_bit(22, value);
+    }
+
+    /*
+        FIXME: There are MBE and SBE bits in 1.12; once Privileged Specification version 1.12
+        is ratified, there should be read functions of these bits as well.
+    */
+
+    /// Whether either the FS field or XS field
+    /// signals the presence of some dirty state
+    #[inline]
+    pub fn set_sd(&mut self, value: bool) {
+        self.bits.set_bit(size_of::<usize>() * 8 - 1, value);
+    }
+
+    /// User Interrupt Enable
+    #[inline]
     pub fn uie(&self) -> bool {
         self.bits.get_bit(0)
     }

--- a/src/register/mstatus.rs
+++ b/src/register/mstatus.rs
@@ -57,54 +57,54 @@ pub enum SPP {
 }
 
 impl Mstatus {
-    /// User Interrupt Enable
+    /// Set bit for User Interrupt Enable
     #[inline]
-    pub fn set_uie(&mut self, value: bool) {
+    pub fn bitset_uie(&mut self, value: bool) {
         self.bits.set_bit(0, value);
     }
 
     /// Supervisor Interrupt Enable
     #[inline]
-    pub fn set_sie(&mut self, value: bool) {
+    pub fn bitset_sie(&mut self, value: bool) {
         self.bits.set_bit(1, value);
     }
 
-    /// Machine Interrupt Enable
+    /// Set bit for Machine Interrupt Enable
     #[inline]
-    pub fn set_mie(&mut self, value: bool) {
+    pub fn bitset_mie(&mut self, value: bool) {
         self.bits.set_bit(3, value);
     }
 
-    /// User Previous Interrupt Enable
+    /// Set bit for User Previous Interrupt Enable
     #[inline]
-    pub fn set_upie(&mut self, value: bool) {
+    pub fn bitset_upie(&mut self, value: bool) {
         self.bits.set_bit(4, value);
     }
 
-    /// Supervisor Previous Interrupt Enable
+    /// Set bit for Supervisor Previous Interrupt Enable
     #[inline]
-    pub fn set_spie(&mut self, value: bool) {
+    pub fn bitset_spie(&mut self, value: bool) {
         self.bits.set_bit(5, value);
     }
 
-    /// Machine Previous Interrupt Enable
+    /// Set bit for Machine Previous Interrupt Enable
     #[inline]
-    pub fn set_mpie(&mut self, value: bool) {
+    pub fn bitset_mpie(&mut self, value: bool) {
         self.bits.set_bit(7, value);
     }
 
-    /// Supervisor Previous Privilege Mode
+    /// Set bit for Supervisor Previous Privilege Mode
     #[inline]
-    pub fn set_spp(&mut self, spp: SPP) {
+    pub fn bitset_spp(&mut self, spp: SPP) {
         match spp {
             SPP::Supervisor => self.bits.set_bit(8, true),
             SPP::User => self.bits.set_bit(8, false),
         };
     }
 
-    /// Machine Previous Privilege Mode
+    /// Set bit for Machine Previous Privilege Mode
     #[inline]
-    pub fn set_mpp(&mut self, mpp: MPP) {
+    pub fn bitset_mpp(&mut self, mpp: MPP) {
         match mpp {
             MPP::User => self.bits.set_bits(11..13, 0b00),
             MPP::Supervisor => self.bits.set_bits(11..13, 0b01),
@@ -112,12 +112,12 @@ impl Mstatus {
         };
     }
 
-    /// Floating-point extension state
+    /// Set bit for Floating-point extension state
     ///
     /// Encodes the status of the floating-point unit,
     /// including the CSR `fcsr` and floating-point data registers `f0–f31`.
     #[inline]
-    pub fn set_fs(&mut self, fs: FS) {
+    pub fn bitset_fs(&mut self, fs: FS) {
         match fs {
             FS::Off => self.bits.set_bits(13..15, 0b00),
             FS::Initial => self.bits.set_bits(13..15, 0b01),
@@ -126,11 +126,11 @@ impl Mstatus {
         };
     }
 
-    /// Additional extension state
+    /// Set bit for Additional extension state
     ///
     /// Encodes the status of additional user-mode extensions and associated state.
     #[inline]
-    pub fn set_xs(&mut self, xs: XS) {
+    pub fn bitset_xs(&mut self, xs: XS) {
         match xs {
             XS::AllOff => self.bits.set_bits(15..17, 0b00),
             XS::NoneDirtyOrClean => self.bits.set_bits(15..17, 0b01),
@@ -139,36 +139,36 @@ impl Mstatus {
         };
     }
 
-    /// Modify Memory PRiVilege
+    /// Set bit for Modify Memory PRiVilege
     #[inline]
-    pub fn set_mprv(&mut self, value: bool) {
+    pub fn bitset_mprv(&mut self, value: bool) {
         self.bits.set_bit(17, value);
     }
 
-    /// Permit Supervisor User Memory access
+    /// Set bit for Permit Supervisor User Memory access
     #[inline]
-    pub fn set_sum(&mut self, value: bool) {
+    pub fn bitset_sum(&mut self, value: bool) {
         self.bits.set_bit(18, value);
     }
 
-    /// Make eXecutable Readable
+    /// Set bit for Make eXecutable Readable
     #[inline]
-    pub fn set_mxr(&mut self, value: bool) {
+    pub fn bitset_mxr(&mut self, value: bool) {
         self.bits.set_bit(19, value);
     }
 
-    /// Trap Virtual Memory
+    /// Set bit for Trap Virtual Memory
     ///
     /// If this bit is set, reads or writes to `satp` CSR or execute `sfence.vma`
     /// instruction when in S-mode will raise an illegal instruction exception.
     ///
     /// TVM is hard-wired to 0 when S-mode is not supported.
     #[inline]
-    pub fn set_tvm(&mut self, value: bool) {
+    pub fn bitset_tvm(&mut self, value: bool) {
         self.bits.set_bit(20, value);
     }
 
-    /// Timeout Wait
+    /// Set bit for Timeout Wait
     ///
     /// Indicates that if WFI instruction should be intercepted.
     ///
@@ -178,32 +178,33 @@ impl Mstatus {
     ///
     /// TW is hard-wired to 0 when S-mode is not supported.
     #[inline]
-    pub fn set_tw(&mut self, value: bool) {
+    pub fn bitset_tw(&mut self, value: bool) {
         self.bits.set_bit(21, value);
     }
 
-    /// Trap SRET
+    /// Set bit for Trap SRET
     ///
     /// Indicates that if SRET instruction should be trapped to raise illegal
     /// instruction exception.
     ///
     /// If S-mode is not supported, TSR bit is hard-wired to 0.
     #[inline]
-    pub fn set_tsr(&mut self, value: bool) {
+    pub fn bitset_tsr(&mut self, value: bool) {
         self.bits.set_bit(22, value);
+    }
+
+    /// Apply the bits into actual mstatus register.
+    #[inline]
+    pub fn apply(&self) {
+        unsafe {
+            _write(self.bits);
+        }
     }
 
     /*
         FIXME: There are MBE and SBE bits in 1.12; once Privileged Specification version 1.12
         is ratified, there should be read functions of these bits as well.
     */
-
-    /// Whether either the FS field or XS field
-    /// signals the presence of some dirty state
-    #[inline]
-    pub fn set_sd(&mut self, value: bool) {
-        self.bits.set_bit(size_of::<usize>() * 8 - 1, value);
-    }
 
     /// User Interrupt Enable
     #[inline]


### PR DESCRIPTION
As the inner structure of `Mstatus` is private, it's inconvient to prepare/keep track of a `mstatus` for a certain kind of supervisor runtime.

Especially when prepare for `mstatus`, if the interrupt bit like `MIE` is enabled, then a interrupt maybe triggered unwantedly.

So I think it's maybe a good idea to add some setter for these fields.

But I do concern about the amibigiouty of these instance method comparing to the register setters.

![image](https://user-images.githubusercontent.com/18240025/124342943-69797e00-dbb7-11eb-9feb-1f9b34dca43e.png)
