### PR TITLE
feat: Use new asm! instead of llvm_asm!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Use new `asm!` instead of `llvm_asm!`
+
 ## [v0.7.0] - 2020-07-29
 
 ### Added

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -7,7 +7,7 @@ macro_rules! instruction {
         pub unsafe fn $fnname() {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => llvm_asm!($asm :::: "volatile"),
+                () => asm!($asm),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -58,7 +58,7 @@ instruction!(
 pub unsafe fn sfence_vma(asid: usize, addr: usize) {
     match () {
         #[cfg(all(riscv, feature = "inline-asm"))]
-        () => llvm_asm!("sfence.vma $0, $1" :: "r"(asid), "r"(addr) :: "volatile"),
+        () => asm!("sfence.vma {0}, {1}", in(reg) asid, in(reg) addr),
 
         #[cfg(all(riscv, not(feature = "inline-asm")))]
         () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! - Wrappers around assembly instructions like `WFI`.
 
 #![no_std]
-#![cfg_attr(feature = "inline-asm", feature(llvm_asm))]
+#![cfg_attr(feature = "inline-asm", feature(asm))]
 
 extern crate bare_metal;
 extern crate bit_field;

--- a/src/register/macros.rs
+++ b/src/register/macros.rs
@@ -7,7 +7,7 @@ macro_rules! read_csr {
                 #[cfg(all(riscv, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    llvm_asm!("csrrs $0, $1, x0" : "=r"(r) : "i"($csr_number) :: "volatile");
+                    asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
                     r
                 }
 
@@ -36,7 +36,7 @@ macro_rules! read_csr_rv32 {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    llvm_asm!("csrrs $0, $1, x0" : "=r"(r) : "i"($csr_number) :: "volatile");
+                    asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
                     r
                 }
 
@@ -102,7 +102,7 @@ macro_rules! write_csr {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => llvm_asm!("csrrw x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -128,7 +128,7 @@ macro_rules! write_csr_rv32 {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
-                () => llvm_asm!("csrrw x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv32, not(feature = "inline-asm")))]
                 () => {
@@ -178,7 +178,7 @@ macro_rules! set {
         unsafe fn _set(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => llvm_asm!("csrrs x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => asm!("csrrs x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -204,7 +204,7 @@ macro_rules! clear {
         unsafe fn _clear(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => llvm_asm!("csrrc x0, $1, $0" :: "r"(bits), "i"($csr_number) :: "volatile"),
+                () => asm!("csrrc x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {


### PR DESCRIPTION
The new `asm` macro has been merged into `nightly` for some time, while `llvm_asm` will be gradually deprecated and will not enter `stable`. This PR replaces `llvm_asm` with `asm`, but there are still some minor issues to discuss.

My reference are:
- [asm feature](https://doc.rust-lang.org/unstable-book/library-features/asm.html)
- [arch/cortex-m: change a few llvm_asm!s to asm!s](https://github.com/tock/tock/pull/2092)
- [Convert all uses of llvm_asm! to asm!](https://github.com/rust-lang/stdarch/pull/1052)

---

In the new `asm` feature, there are several options can set to optimize codes. [options](https://doc.rust-lang.org/unstable-book/library-features/asm.html#options-1)

However, I'm not quite sure which options to set. (Sort of newbie to asm in rust)