### PR TITLE
Bug fix: sfence.vma - incorrect operand order

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -58,15 +58,15 @@ instruction!(
 pub unsafe fn sfence_vma(asid: usize, addr: usize) {
     match () {
         #[cfg(all(riscv, feature = "inline-asm"))]
-        () => asm!("sfence.vma {0}, {1}", in(reg) asid, in(reg) addr),
+        () => asm!("sfence.vma {0}, {1}", in(reg) addr, in(reg) asid),
 
         #[cfg(all(riscv, not(feature = "inline-asm")))]
         () => {
             extern "C" {
-                fn __sfence_vma(asid: usize, addr: usize);
+                fn __sfence_vma(addr: usize, asid: usize);
             }
 
-            __sfence_vma(asid, addr);
+            __sfence_vma(addr, asid);
         }
 
         #[cfg(not(riscv))]


### PR DESCRIPTION
There is a bug about the operand order of `riscv::asm::sfence_vma(asid: usize, addr: usize)`. According to [riscv-isa-manual](https://github.com/riscv/riscv-isa-manual/blob/master/src/supervisor.tex#L1198), the first operand should be `vaddr`, and the second be `asid`. But `riscv::asm::sfence_vma` generates assembly code in the reverse order. In fact, our rust-OS which using this instruction to flush TLB have been running into an error until we reverse the parameter order.
I propose a simple solution which leave the function parameter order unchanged. Maybe you guys will change it to be more consistent with the specification. Anyway, let's fix this bug.

