### PR TITLE
Add inline-asm build to CI, fix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,11 @@ jobs:
         run: cargo check --target x86_64-unknown-linux-gnu
       - name: Run CI script for riscv32imac-unknown-none-elf under ${{ matrix.rust }}
         run: cargo check --target riscv32imac-unknown-none-elf
+      - name: Run CI script for riscv32imac-unknown-none-elf (inline-asm) under ${{ matrix.rust }}
+        run: |
+          if [ "${{ matrix.rust }}" == "nightly" ]; then
+            cargo check --target riscv32imac-unknown-none-elf --features inline-asm
+          fi
       - name: Run CI script for riscv64imac-unknown-none-elf under ${{ matrix.rust }}
         run: cargo check --target riscv64imac-unknown-none-elf
       - name: Run CI script for riscv64gc-unknown-none-elf under ${{ matrix.rust }}

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -7,7 +7,7 @@ macro_rules! instruction {
         pub unsafe fn $fnname() {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!($asm),
+                () => core::arch::asm!($asm),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -58,7 +58,7 @@ instruction!(
 pub unsafe fn sfence_vma(asid: usize, addr: usize) {
     match () {
         #[cfg(all(riscv, feature = "inline-asm"))]
-        () => asm!("sfence.vma {0}, {1}", in(reg) addr, in(reg) asid),
+        () => core::arch::asm!("sfence.vma {0}, {1}", in(reg) addr, in(reg) asid),
 
         #[cfg(all(riscv, not(feature = "inline-asm")))]
         () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![no_std]
 #![cfg_attr(feature = "inline-asm", feature(asm))]
+#![cfg_attr(feature = "inline-asm", feature(asm_const))]
 
 extern crate bare_metal;
 extern crate bit_field;

--- a/src/register/macros.rs
+++ b/src/register/macros.rs
@@ -7,7 +7,7 @@ macro_rules! read_csr {
                 #[cfg(all(riscv, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
+                    core::arch::asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
                     r
                 }
 
@@ -36,7 +36,7 @@ macro_rules! read_csr_rv32 {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
                 () => {
                     let r: usize;
-                    asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
+                    core::arch::asm!("csrrs {0}, {1}, x0", out(reg) r, const $csr_number);
                     r
                 }
 
@@ -102,7 +102,7 @@ macro_rules! write_csr {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -128,7 +128,7 @@ macro_rules! write_csr_rv32 {
         unsafe fn _write(bits: usize) {
             match () {
                 #[cfg(all(riscv32, feature = "inline-asm"))]
-                () => asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrw x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv32, not(feature = "inline-asm")))]
                 () => {
@@ -178,7 +178,7 @@ macro_rules! set {
         unsafe fn _set(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrs x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrs x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {
@@ -204,7 +204,7 @@ macro_rules! clear {
         unsafe fn _clear(bits: usize) {
             match () {
                 #[cfg(all(riscv, feature = "inline-asm"))]
-                () => asm!("csrrc x0, {1}, {0}", in(reg) bits, const $csr_number),
+                () => core::arch::asm!("csrrc x0, {1}, {0}", in(reg) bits, const $csr_number),
 
                 #[cfg(all(riscv, not(feature = "inline-asm")))]
                 () => {


### PR DESCRIPTION
https://github.com/rust-embedded/riscv/pull/86 introduced new `asm!` syntax which is enabled with the `inline-asm` feature. However, it doesn't work with current nightly since `asm_const` unstable feature is not enabled. This PR fixes the problem and adds automatic checks to CI.