### PR TITLE
csr: inline register reads and type conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add delay structure and methods using embedded-hal traits and `mcycle` register
 - Add `asm::delay()` function for assembly-based busy-loops
 - Add `asm::nop()`, a wrapper for implementing a `nop` instruction
+- Add missing `#[inline]` attribute to register reads, type conversations and `interrupt::free`
 
 ### Changed
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -9,12 +9,14 @@ pub struct McycleDelay {
 
 impl McycleDelay {
     /// Constructs the delay provider
+    #[inline(always)]
     pub fn new(ticks_second: u32) -> Self {
         Self { ticks_second }
     }
 }
 
 impl DelayUs<u64> for McycleDelay {
+    #[inline(always)]
     fn delay_us(&mut self, us: u64) {
         let t0 = mcycle::read64();
         let clock = (us * (self.ticks_second as u64)) / 1_000_000;
@@ -53,6 +55,7 @@ impl DelayUs<u8> for McycleDelay {
 }
 
 impl DelayMs<u32> for McycleDelay {
+    #[inline(always)]
     fn delay_ms(&mut self, ms: u32) {
         self.delay_us((ms as u64) * 1000)
     }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -16,7 +16,7 @@ impl McycleDelay {
 }
 
 impl DelayUs<u64> for McycleDelay {
-    #[inline(always)]
+    #[inline]
     fn delay_us(&mut self, us: u64) {
         let t0 = mcycle::read64();
         let clock = (us * (self.ticks_second as u64)) / 1_000_000;
@@ -55,7 +55,7 @@ impl DelayUs<u8> for McycleDelay {
 }
 
 impl DelayMs<u32> for McycleDelay {
-    #[inline(always)]
+    #[inline]
     fn delay_ms(&mut self, ms: u32) {
         self.delay_us((ms as u64) * 1000)
     }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -33,6 +33,7 @@ pub unsafe fn enable() {
 /// Execute closure `f` in an interrupt-free context.
 ///
 /// This as also known as a "critical section".
+#[inline]
 pub fn free<F, R>(f: F) -> R
 where
     F: FnOnce(&CriticalSection) -> R,

--- a/src/register/fcsr.rs
+++ b/src/register/fcsr.rs
@@ -76,6 +76,7 @@ pub enum RoundingMode {
 
 impl FCSR {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> u32 {
         self.bits
     }

--- a/src/register/marchid.rs
+++ b/src/register/marchid.rs
@@ -10,6 +10,7 @@ pub struct Marchid {
 
 impl Marchid {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits.get()
     }

--- a/src/register/mcause.rs
+++ b/src/register/mcause.rs
@@ -49,6 +49,7 @@ pub enum Exception {
 }
 
 impl Interrupt {
+    #[inline]
     pub fn from(nr: usize) -> Self {
         match nr {
             0 => Interrupt::UserSoft,
@@ -66,6 +67,7 @@ impl Interrupt {
 }
 
 impl Exception {
+    #[inline]
     pub fn from(nr: usize) -> Self {
         match nr {
             0 => Exception::InstructionMisaligned,
@@ -94,6 +96,7 @@ impl Mcause {
     }
 
     /// Returns the code field
+    #[inline]
     pub fn code(&self) -> usize {
         match () {
             #[cfg(target_pointer_width = "32")]

--- a/src/register/mimpid.rs
+++ b/src/register/mimpid.rs
@@ -10,6 +10,7 @@ pub struct Mimpid {
 
 impl Mimpid {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits.get()
     }

--- a/src/register/misa.rs
+++ b/src/register/misa.rs
@@ -18,11 +18,13 @@ pub enum MXL {
 
 impl Misa {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits.get()
     }
 
     /// Returns the machine xlen.
+    #[inline]
     pub fn mxl(&self) -> MXL {
         let value = match () {
             #[cfg(target_pointer_width = "32")]
@@ -39,6 +41,7 @@ impl Misa {
     }
 
     /// Returns true when the atomic extension is implemented.
+    #[inline]
     pub fn has_extension(&self, extension: char) -> bool {
         let bit = extension as u8 - 65;
         if bit > 25 {

--- a/src/register/mtvec.rs
+++ b/src/register/mtvec.rs
@@ -15,16 +15,19 @@ pub enum TrapMode {
 
 impl Mtvec {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits
     }
 
     /// Returns the trap-vector base-address
+    #[inline]
     pub fn address(&self) -> usize {
         self.bits - (self.bits & 0b11)
     }
 
     /// Returns the trap-vector mode
+    #[inline]
     pub fn trap_mode(&self) -> Option<TrapMode> {
         let mode = self.bits & 0b11;
         match mode {

--- a/src/register/mvendorid.rs
+++ b/src/register/mvendorid.rs
@@ -10,11 +10,13 @@ pub struct Mvendorid {
 
 impl Mvendorid {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits.get()
     }
 
     /// Returns the JEDEC manufacturer ID
+    #[inline]
     pub fn jedec_manufacturer(&self) -> usize {
         self.bits() >> 7
     }

--- a/src/register/scause.rs
+++ b/src/register/scause.rs
@@ -46,6 +46,7 @@ pub enum Exception {
 }
 
 impl Interrupt {
+    #[inline]
     pub fn from(nr: usize) -> Self {
         match nr {
             0 => Interrupt::UserSoft,
@@ -60,6 +61,7 @@ impl Interrupt {
 }
 
 impl Exception {
+    #[inline]
     pub fn from(nr: usize) -> Self {
         match nr {
             0 => Exception::InstructionMisaligned,
@@ -86,6 +88,7 @@ impl Scause {
     }
 
     /// Returns the code field
+    #[inline]
     pub fn code(&self) -> usize {
         let bit = 1 << (size_of::<usize>() * 8 - 1);
         self.bits & !bit

--- a/src/register/stvec.rs
+++ b/src/register/stvec.rs
@@ -10,16 +10,19 @@ pub struct Stvec {
 
 impl Stvec {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits
     }
 
     /// Returns the trap-vector base-address
+    #[inline]
     pub fn address(&self) -> usize {
         self.bits - (self.bits & 0b11)
     }
 
     /// Returns the trap-vector mode
+    #[inline]
     pub fn trap_mode(&self) -> Option<TrapMode> {
         let mode = self.bits & 0b11;
         match mode {

--- a/src/register/utvec.rs
+++ b/src/register/utvec.rs
@@ -10,16 +10,19 @@ pub struct Utvec {
 
 impl Utvec {
     /// Returns the contents of the register as raw bits
+    #[inline]
     pub fn bits(&self) -> usize {
         self.bits
     }
 
     /// Returns the trap-vector base-address
+    #[inline]
     pub fn address(&self) -> usize {
         self.bits - (self.bits & 0b11)
     }
 
     /// Returns the trap-vector mode
+    #[inline]
     pub fn trap_mode(&self) -> Option<TrapMode> {
         let mode = self.bits & 0b11;
         match mode {


### PR DESCRIPTION
This pull request adds missing `#[inline]` flags on field read functions and type conversations. Field `#[inline]` marks to enable inline function optimization which speed up the code when used to build kernels and hypervisors.

Please hint me if there are more missing `#[inline]` flags in project `riscv` so I may include them in this fix too.

Off topic: would it be the time to release a 0.7.1 version now? Then we do not need to pin to commit numbers when developing risc-v projects.

r? @Disasm