### PR TITLE
Add extra documentation for `delay`

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,3 +1,4 @@
+//! Delay devices and providers
 use crate::register::mcycle;
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -8,7 +8,8 @@ pub struct McycleDelay {
 }
 
 impl McycleDelay {
-    /// Constructs the delay provider
+    /// Constructs the delay provider.
+    /// `ticks_second` should be the clock speed of the core, in Hertz
     #[inline(always)]
     pub fn new(ticks_second: u32) -> Self {
         Self { ticks_second }


### PR DESCRIPTION
Took me a minute or two to figure out what value exactly to pass to `McycleDelay::new`, so figured I'd make a quick PR to add a note for anyone else that hits the same confusion as I did. Also added a doc line for the `delay` module while I was at it, as it was missing one.