### PR TITLE
fix reading marchid and mimpid

### DIFF
--- a/src/register/marchid.rs
+++ b/src/register/marchid.rs
@@ -16,7 +16,7 @@ impl Marchid {
     }
 }
 
-read_csr!(0xF11);
+read_csr!(0xF12);
 
 /// Reads the CSR
 #[inline]

--- a/src/register/mimpid.rs
+++ b/src/register/mimpid.rs
@@ -16,7 +16,7 @@ impl Mimpid {
     }
 }
 
-read_csr!(0xF11);
+read_csr!(0xF13);
 
 /// Reads the CSR
 #[inline]


### PR DESCRIPTION
It seems to have been a copy-paste error.
We ran into a very nasty bug in oreboot on the Allwinner D1 (C906) where
an errata patch in Linux relies on those two being zero.

Signed-off-by: Daniel Maslowski <info@orangecms.org>