### PR TITLE
Update to edition 2021.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riscv"
 version = "0.8.0"
+edition = "2021"
 rust-version = "1.59"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,8 +1,8 @@
 //! Interrupts
 
 // NOTE: Adapted from cortex-m/src/interrupt.rs
+use crate::register::mstatus;
 pub use bare_metal::{CriticalSection, Mutex};
-use register::mstatus;
 
 /// Disables all interrupts
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,6 @@
 
 #![no_std]
 
-extern crate bare_metal;
-extern crate bit_field;
-extern crate embedded_hal;
-
 pub mod asm;
 pub mod delay;
 pub mod interrupt;


### PR DESCRIPTION
This shouldn't be a breaking change since Edition 2021 came out in
Rust 1.56, and MSRV is already higher than that (Rust 1.59)