### PR TITLE
Fix `interrupt::free()` unsoundness on multicore systems.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,14 @@ jobs:
         run: cargo check --target riscv64imac-unknown-none-elf
       - name: Run CI script for riscv64gc-unknown-none-elf under ${{ matrix.rust }}
         run: cargo check --target riscv64gc-unknown-none-elf
+      - name: Run CI script for x86_64-unknown-linux-gnu under ${{ matrix.rust }} with critical-section-single-core
+        run: cargo check --target x86_64-unknown-linux-gnu --features critical-section-single-core
+      - name: Run CI script for riscv32imac-unknown-none-elf under ${{ matrix.rust }} with critical-section-single-core
+        run: cargo check --target riscv32imac-unknown-none-elf --features critical-section-single-core
+      - name: Run CI script for riscv64imac-unknown-none-elf under ${{ matrix.rust }} with critical-section-single-core
+        run: cargo check --target riscv64imac-unknown-none-elf --features critical-section-single-core
+      - name: Run CI script for riscv64gc-unknown-none-elf under ${{ matrix.rust }} with critical-section-single-core
+        run: cargo check --target riscv64gc-unknown-none-elf --features critical-section-single-core
 
   # On macOS and Windows, we at least make sure that the crate builds and links.
   build-other:
@@ -56,4 +64,4 @@ jobs:
           toolchain: stable
           override: true
       - name: Build crate for host OS
-        run: cargo build
+        run: cargo build --features critical-section-single-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `critical-section-single-core` feature which provides an implementation for the `critical_section` crate for single-core systems, based on disabling all interrupts.
+
 ### Fixed
 
 - Fix `asm::delay()` to ensure count register is always reloaded

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ targets = [
 critical-section-single-core = ["critical-section/restore-state-bool"]
 
 [dependencies]
-bare-metal = "1.0.0"
 bit_field = "0.10.0"
 critical-section = "1.1.0"
 embedded-hal = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ targets = [
     "riscv64imac-unknown-none-elf", "riscv64gc-unknown-none-elf",
 ]
 
+[features]
+critical-section-single-core = ["critical-section/restore-state-bool"]
+
 [dependencies]
 bare-metal = "1.0.0"
 bit_field = "0.10.0"
+critical-section = "1.1.0"
 embedded-hal = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riscv"
 version = "0.8.0"
+edition = "2021"
 rust-version = "1.59"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]

--- a/src/critical_section.rs
+++ b/src/critical_section.rs
@@ -1,0 +1,22 @@
+use critical_section::{set_impl, Impl, RawRestoreState};
+
+use crate::interrupt;
+use crate::register::mstatus;
+
+struct SingleCoreCriticalSection;
+set_impl!(SingleCoreCriticalSection);
+
+unsafe impl Impl for SingleCoreCriticalSection {
+    unsafe fn acquire() -> RawRestoreState {
+        let was_active = mstatus::read().mie();
+        interrupt::disable();
+        was_active
+    }
+
+    unsafe fn release(was_active: RawRestoreState) {
+        // Only re-enable interrupts if they were enabled before the critical section.
+        if was_active {
+            interrupt::enable()
+        }
+    }
+}

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,8 +1,8 @@
 //! Interrupts
 
 // NOTE: Adapted from cortex-m/src/interrupt.rs
+use crate::register::mstatus;
 pub use bare_metal::{CriticalSection, Mutex};
-use register::mstatus;
 
 /// Disables all interrupts
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,6 @@
 
 #![no_std]
 
-extern crate bare_metal;
-extern crate bit_field;
-extern crate embedded_hal;
-
 pub mod asm;
 pub mod delay;
 pub mod interrupt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,6 @@ pub mod register;
 
 #[macro_use]
 mod macros;
+
+#[cfg(all(riscv, feature = "critical-section-single-core"))]
+mod critical_section;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,10 @@ mod macros;
 
 #[cfg(all(riscv, feature = "critical-section-single-core"))]
 mod critical_section;
+
+/// Used to reexport items for use in macros. Do not use directly.
+/// Not covered by semver guarantees.
+#[doc(hidden)]
+pub mod _export {
+    pub use critical_section;
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,7 +6,10 @@
 /// at most once in the whole lifetime of the program.
 ///
 /// # Note
-/// this macro is unsound on multi-core systems
+///
+/// this macro requires a `critical-section` implementation to be set. For single core systems, you can
+/// enable the `critical-section-single-core` feature for this crate. For multi core systems, you
+/// have to provide one from elsewhere, typically your chip's HAL crate.
 ///
 /// # Example
 ///
@@ -29,7 +32,7 @@
 #[macro_export]
 macro_rules! singleton {
     (: $ty:ty = $expr:expr) => {
-        $crate::interrupt::free(|_| {
+        $crate::_export::critical_section::with(|_| {
             static mut VAR: Option<$ty> = None;
 
             #[allow(unsafe_code)]


### PR DESCRIPTION
depends on #109, #110

This is unsound on multicore systems because it only disables interrupts in the
current core. For multicore chips, a chip-specific critical section implementation
is needed instead.

Unsoundness is fixed by not returning the `CriticalSection` token.

This is a breaking change.

This is the riscv equivalent of https://github.com/rust-embedded/cortex-m/pull/447