### PR TITLE
Propose to release a version `riscv` v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.8.1] - 2022-10-06
+
 ### Fixed
 
 - Fix `asm::delay()` to ensure count register is always reloaded
+- Fix reading marchid and mimpid (#107)
 
 ## [v0.8.0] - 2022-04-20
 
@@ -89,7 +92,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed MSRV by restricting the upper bound of `bare-metal` version
 
-[Unreleased]: https://github.com/rust-embedded/riscv/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/riscv/compare/v0.8.1...HEAD
+[v0.8.1]: https://github.com/rust-embedded/riscv/compare/v0.8.1...v0.8.0
 [v0.8.0]: https://github.com/rust-embedded/riscv/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/rust-embedded/riscv/compare/v0.6.0...v0.7.0
 [v0.6.0]: https://github.com/rust-embedded/riscv/compare/v0.5.6...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.59"
 repository = "https://github.com/rust-embedded/riscv"


### PR DESCRIPTION
The `riscv` crate includes an important fix (https://github.com/rust-embedded/riscv/pull/107) where the RustSBI community would leverage the use of. However, the latest release v0.8.0 did not include this fix. In this pull request we want to propose to release a new version of `riscv` crate to include at least this fix, so that RustSBI community would write correct implemenations based on this crate.

Notes to `CHANGELOG.md`: the release date `2022-10-06` can always be changed.

r? @Disasm 