### PR TITLE
bump version to v0.9.0 due to breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.8.1] - 2022-10-06
+## [v0.9.0] - 2022-10-06
 
 ### Fixed
 
 - Fix `asm::delay()` to ensure count register is always reloaded
 - Fix reading marchid and mimpid (#107)
+
+### Removed
+- `set_msoft`, `clear_msoft`, `set_mtimer` and `clear_mtimer` removed as part of fixing issue #62
 
 ## [v0.8.0] - 2022-04-20
 
@@ -92,8 +95,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed MSRV by restricting the upper bound of `bare-metal` version
 
-[Unreleased]: https://github.com/rust-embedded/riscv/compare/v0.8.1...HEAD
-[v0.8.1]: https://github.com/rust-embedded/riscv/compare/v0.8.1...v0.8.0
+[Unreleased]: https://github.com/rust-embedded/riscv/compare/v0.9.0...HEAD
+[v0.9.0]: https://github.com/rust-embedded/riscv/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/rust-embedded/riscv/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/rust-embedded/riscv/compare/v0.6.0...v0.7.0
 [v0.6.0]: https://github.com/rust-embedded/riscv/compare/v0.5.6...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.59"
 repository = "https://github.com/rust-embedded/riscv"


### PR DESCRIPTION
As per discussion on https://github.com/rust-embedded/riscv/pull/112 we want to release `v0.9.0` and yank `v0.8.1` since the removals were a breaking change.