### PR TITLE
fix critial section implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix implementation for `SingleHartCriticalSection`
+
 ## [v0.10.0] - 2022-11-09
 
 ### Added

--- a/src/critical_section.rs
+++ b/src/critical_section.rs
@@ -9,7 +9,7 @@ set_impl!(SingleHartCriticalSection);
 unsafe impl Impl for SingleHartCriticalSection {
     unsafe fn acquire() -> RawRestoreState {
         let mut mstatus: usize;
-        core::arch::asm!("csrrci {}, 0x300, 0b100", out(reg) mstatus);
+        core::arch::asm!("csrrci {}, mstatus, 0b1000", out(reg) mstatus);
         core::mem::transmute::<_, mstatus::Mstatus>(mstatus).mie()
     }
 


### PR DESCRIPTION
It should be `0b1000` rather than `0b100`. `Bit 2` is a reserved bit, and `Bit 3` is `MIE` that needs to be cleared.

![image](https://user-images.githubusercontent.com/19427212/212855746-7df197f1-5582-4844-a58e-6c7269d03b22.png)
