### PR TITLE
Added clippy to the CI workflow

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -1,0 +1,36 @@
+name: Clippy
+
+on:
+  push:
+    branches: [ staging, trying, master ]
+  pull_request:
+    branches: [ master ]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CLIPPY_PARAMS: -W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cargo_flags:
+          - "--no-default-features"
+          - "--all-features"
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Run clippy
+        run: cargo clippy --all ${{ matrix.cargo_flags }} -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //! a target-specific implementation instead, typically provided by a HAL or RTOS crate.
 
 #![no_std]
+#![allow(clippy::missing_safety_doc)]
 
 pub mod asm;
 pub mod delay;

--- a/src/register/mcounteren.rs
+++ b/src/register/mcounteren.rs
@@ -30,7 +30,7 @@ impl Mcounteren {
     /// Supervisor "hpm\[x\]" Enable (bits 3-31)
     #[inline]
     pub fn hpm(&self, index: usize) -> bool {
-        assert!(3 <= index && index < 32);
+        assert!((3..32).contains(&index));
         self.bits.get_bit(index)
     }
 }
@@ -54,12 +54,12 @@ set_clear_csr!(
 
 #[inline]
 pub unsafe fn set_hpm(index: usize) {
-    assert!(3 <= index && index < 32);
+    assert!((3..32).contains(&index));
     _set(1 << index);
 }
 
 #[inline]
 pub unsafe fn clear_hpm(index: usize) {
-    assert!(3 <= index && index < 32);
+    assert!((3..32).contains(&index));
     _clear(1 << index);
 }

--- a/src/register/mstatus.rs
+++ b/src/register/mstatus.rs
@@ -9,7 +9,6 @@
 
 use bit_field::BitField;
 
-
 /// mstatus register
 #[derive(Clone, Copy, Debug)]
 pub struct Mstatus {

--- a/src/register/mstatus.rs
+++ b/src/register/mstatus.rs
@@ -8,7 +8,7 @@
 // which would be the best way we implement this using Rust?
 
 use bit_field::BitField;
-use core::mem::size_of;
+
 
 /// mstatus register
 #[derive(Clone, Copy, Debug)]
@@ -205,7 +205,7 @@ impl Mstatus {
     /// signals the presence of some dirty state
     #[inline]
     pub fn sd(&self) -> bool {
-        self.bits.get_bit(size_of::<usize>() * 8 - 1)
+        self.bits.get_bit(usize::BITS as usize - 1)
     }
 }
 

--- a/src/register/pmpcfgx.rs
+++ b/src/register/pmpcfgx.rs
@@ -72,7 +72,7 @@ impl Pmpcsr {
                 3 => Range::NAPOT,
                 _ => unreachable!(),
             },
-            locked: byte.get_bit(7) as bool,
+            locked: byte.get_bit(7),
         }
     }
 }

--- a/src/register/scause.rs
+++ b/src/register/scause.rs
@@ -2,7 +2,6 @@
 
 use bit_field::BitField;
 
-
 /// scause register
 #[derive(Clone, Copy)]
 pub struct Scause {

--- a/src/register/scause.rs
+++ b/src/register/scause.rs
@@ -1,7 +1,7 @@
 //! scause register
 
 use bit_field::BitField;
-use core::mem::size_of;
+
 
 /// scause register
 #[derive(Clone, Copy)]
@@ -90,7 +90,7 @@ impl Scause {
     /// Returns the code field
     #[inline]
     pub fn code(&self) -> usize {
-        let bit = 1 << (size_of::<usize>() * 8 - 1);
+        let bit = 1 << (usize::BITS as usize - 1);
         self.bits & !bit
     }
 
@@ -107,7 +107,7 @@ impl Scause {
     /// Is trap cause an interrupt.
     #[inline]
     pub fn is_interrupt(&self) -> bool {
-        self.bits.get_bit(size_of::<usize>() * 8 - 1)
+        self.bits.get_bit(usize::BITS as usize - 1)
     }
 
     /// Is trap cause an exception.
@@ -139,7 +139,7 @@ pub unsafe fn set(cause: Trap) {
                 Interrupt::UserExternal => 8,
                 Interrupt::SupervisorExternal => 9,
                 Interrupt::Unknown => panic!("unknown interrupt"),
-            } | (1 << (size_of::<usize>() * 8 - 1)))
+            } | (1 << (usize::BITS as usize - 1)))
         } // interrupt bit is 1
         Trap::Exception(e) => match e {
             Exception::InstructionMisaligned => 0,

--- a/src/register/scounteren.rs
+++ b/src/register/scounteren.rs
@@ -30,7 +30,7 @@ impl Scounteren {
     /// User "hpm\[x\]" Enable (bits 3-31)
     #[inline]
     pub fn hpm(&self, index: usize) -> bool {
-        assert!(3 <= index && index < 32);
+        assert!((3..32).contains(&index));
         self.bits.get_bit(index)
     }
 }
@@ -54,12 +54,12 @@ set_clear_csr!(
 
 #[inline]
 pub unsafe fn set_hpm(index: usize) {
-    assert!(3 <= index && index < 32);
+    assert!((3..32).contains(&index));
     _set(1 << index);
 }
 
 #[inline]
 pub unsafe fn clear_hpm(index: usize) {
-    assert!(3 <= index && index < 32);
+    assert!((3..32).contains(&index));
     _clear(1 << index);
 }

--- a/src/register/sstatus.rs
+++ b/src/register/sstatus.rs
@@ -2,7 +2,7 @@
 
 pub use super::mstatus::FS;
 use bit_field::BitField;
-use core::mem::size_of;
+
 
 /// Supervisor Status Register
 #[derive(Clone, Copy, Debug)]
@@ -92,7 +92,7 @@ impl Sstatus {
     /// signals the presence of some dirty state
     #[inline]
     pub fn sd(&self) -> bool {
-        self.bits.get_bit(size_of::<usize>() * 8 - 1)
+        self.bits.get_bit(usize::BITS as usize - 1)
     }
 }
 

--- a/src/register/sstatus.rs
+++ b/src/register/sstatus.rs
@@ -3,7 +3,6 @@
 pub use super::mstatus::FS;
 use bit_field::BitField;
 
-
 /// Supervisor Status Register
 #[derive(Clone, Copy, Debug)]
 pub struct Sstatus {


### PR DESCRIPTION
I've been working with this crate for a while and noticed that it didn't include clippy as part of the CI process. This PR checks that clippy does not trigger any warning for new contributions. I also ran `cargo clippy --fix` to "fix" the crate.

If you think this is useful, I can adapt other repos (e.g., riscv-rt or e310x). Cheers!