### PR TITLE
lib: gate delay module and asm under `delay` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.10.1] - 2023-01-18
 
+### Added
+
+- lib: gate delay module and asm under `delay` feature
+
 ### Fixed
 
 - Fix implementation for `SingleHartCriticalSection`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ targets = [
 
 [features]
 critical-section-single-hart = ["critical-section/restore-state-bool"]
+delay = ["embedded-hal"]
 
 [dependencies]
 bit_field = "0.10.0"
 critical-section = "1.1.0"
-embedded-hal = "0.2.6"
+embedded-hal = { version = "0.2.6", optional = true }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -70,6 +70,7 @@ pub unsafe fn sfence_vma(asid: usize, addr: usize) {
 /// and the execution time may vary with other factors. This delay is mainly useful for simple
 /// timer-less initialization of peripherals if and only if accurate timing is not essential. In
 /// any other case please use a more accurate method to produce a delay.
+#[cfg(feature = "delay")]
 #[inline]
 #[allow(unused_variables)]
 pub unsafe fn delay(cycles: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 pub mod asm;
+#[cfg(feature = "delay")]
 pub mod delay;
 pub mod interrupt;
 pub mod register;


### PR DESCRIPTION
RISC-V Privileged Specification and Unprivileged Specification didn't really define a standard way of delaying a period of time. We gate delay features in `riscv` crate under `delay` feature, so users may enable this feature to use those custom features.

r? @dkhayes117 