### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,6 +5,6 @@ status = [
     "build-riscv (stable%)",
     "build-riscv (1.59.0%)",
     "build-others (%)",
-    "clippy (stable%),
+    "clippy (stable%)",
     "rustfmt",
 ]

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,9 +2,9 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = [
-    "ci-linux (stable)",
-    "ci-linux (1.59.0)",
-    "build-other (macOS-latest)",
-    "build-other (windows-latest)",
-    "Rustfmt"
+    "build-riscv (stable%)",
+    "build-riscv (1.59.0%)",
+    "build-others (%)",
+    "clippy (stable%),
+    "rustfmt",
 ]

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,9 +2,7 @@ block_labels = ["needs-decision"]
 delete_merged_branches = true
 required_approvals = 1
 status = [
-    "build-riscv (stable%)",
-    "build-riscv (1.59.0%)",
-    "build-others (%)",
-    "clippy (stable%)",
+    "build-check",
+    "clippy-check",
     "rustfmt",
 ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,11 +4,11 @@ on:
   pull_request:
   merge_group:
 
-name: Continuous integration
+name: Build check
 
 jobs:
   # We check that the crate builds and links for all the toolchains and targets.
-  ci-riscv:
+  build-riscv:
     strategy:
       matrix:
         # All generated code should be running on stable now, MRSV is 1.59.0
@@ -17,7 +17,7 @@ jobs:
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf
           - riscv32imac-unknown-none-elf
-          - riscv64gc-unknown-linux-gnu
+          - riscv64imac-unknown-none-elf
           - riscv64gc-unknown-none-elf
         cargo_flags: [ "--no-default-features", "--all-features" ]
         include:
@@ -36,7 +36,7 @@ jobs:
       run: cargo build --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
       
   # On MacOS, Ubuntu, and Windows, we at least make sure that the crate builds and links.
-  ci-others:
+  build-others:
     strategy:
       matrix:
         os:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,3 +50,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Build crate for host OS
         run: cargo build ${{ matrix.cargo_flags }}
+  
+  # Job to check that all the builds succeeded
+  build-check:
+    needs:
+    - build-riscv
+    - build-others
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,21 +2,18 @@ on:
   push:
     branches: [ staging, trying, master ]
   pull_request:
+  merge_group:
 
 name: Continuous integration
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
-  # On Linux, we check that the crate builds and links for all the toolchains and targets.
-  ci-linux:
+  # We check that the crate builds and links for all the toolchains and targets.
+  ci-riscv:
     strategy:
       matrix:
         # All generated code should be running on stable now, MRSV is 1.59.0
         toolchain: [ stable, nightly, 1.59.0 ]
         target:
-          - x86_64-unknown-linux-gnu
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf
           - riscv32imac-unknown-none-elf
@@ -25,25 +22,25 @@ jobs:
         cargo_flags: [ "--no-default-features", "--all-features" ]
         include:
           # Nightly is only for reference and allowed to fail
-          - rust: nightly
+          - toolchain: nightly
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental || false }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
       with:
-        toolchain: ${{ matrix.toolchain }}
         targets: ${{ matrix.target }}
     - name: Build library
       run: cargo build --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
       
-  # On macOS and Windows, we at least make sure that the crate builds and links.
+  # On MacOS, Ubuntu, and Windows, we at least make sure that the crate builds and links.
   ci-others:
     strategy:
       matrix:
         os:
-          - macOS-latest
+          - macos-latest
+          - ubuntu-latest
           - windows-latest
         cargo_flags: [ "--no-default-features", "--all-features" ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,9 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
+    - uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: ${{ matrix.toolchain }}
         targets: ${{ matrix.target }}
     - name: Build library
       run: cargo build --target ${{ matrix.target }} ${{ matrix.cargo_flags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,63 +5,50 @@ on:
 
 name: Continuous integration
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
+  # On Linux, we check that the crate builds and links for all the toolchains and targets.
   ci-linux:
-    runs-on: ubuntu-20.04
-    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
         # All generated code should be running on stable now, MRSV is 1.59.0
-        rust: [nightly, stable, 1.59.0]
-
+        toolchain: [ stable, nightly, 1.59.0 ]
+        target:
+          - x86_64-unknown-linux-gnu
+          - riscv32i-unknown-none-elf
+          - riscv32imc-unknown-none-elf
+          - riscv32imac-unknown-none-elf
+          - riscv64gc-unknown-linux-gnu
+          - riscv64gc-unknown-none-elf
+        cargo_flags: [ "--no-default-features", "--all-features" ]
         include:
           # Nightly is only for reference and allowed to fail
           - rust: nightly
             experimental: true
-
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - name: Install all Rust targets for ${{ matrix.rust }}
-        run: rustup target install --toolchain=${{ matrix.rust }} x86_64-unknown-linux-gnu riscv32imac-unknown-none-elf riscv64imac-unknown-none-elf riscv64gc-unknown-none-elf
-      - name: Install riscv gcc
-        run: sudo apt-get update && sudo apt-get install -y gcc-riscv64-unknown-elf
-      - name: Run CI script for x86_64-unknown-linux-gnu under ${{ matrix.rust }}
-        run: cargo check --target x86_64-unknown-linux-gnu
-      - name: Run CI script for riscv32imac-unknown-none-elf under ${{ matrix.rust }}
-        run: cargo check --target riscv32imac-unknown-none-elf
-      - name: Run CI script for riscv64imac-unknown-none-elf under ${{ matrix.rust }}
-        run: cargo check --target riscv64imac-unknown-none-elf
-      - name: Run CI script for riscv64gc-unknown-none-elf under ${{ matrix.rust }}
-        run: cargo check --target riscv64gc-unknown-none-elf
-      - name: Run CI script for x86_64-unknown-linux-gnu under ${{ matrix.rust }} with critical-section-single-hart
-        run: cargo check --target x86_64-unknown-linux-gnu --features critical-section-single-hart
-      - name: Run CI script for riscv32imac-unknown-none-elf under ${{ matrix.rust }} with critical-section-single-hart
-        run: cargo check --target riscv32imac-unknown-none-elf --features critical-section-single-hart
-      - name: Run CI script for riscv64imac-unknown-none-elf under ${{ matrix.rust }} with critical-section-single-hart
-        run: cargo check --target riscv64imac-unknown-none-elf --features critical-section-single-hart
-      - name: Run CI script for riscv64gc-unknown-none-elf under ${{ matrix.rust }} with critical-section-single-hart
-        run: cargo check --target riscv64gc-unknown-none-elf --features critical-section-single-hart
-
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+        targets: ${{ matrix.target }}
+    - name: Build library
+      run: cargo build --target ${{ matrix.target }} ${{ matrix.cargo_flags }}
+      
   # On macOS and Windows, we at least make sure that the crate builds and links.
-  build-other:
+  ci-others:
     strategy:
       matrix:
         os:
           - macOS-latest
           - windows-latest
+        cargo_flags: [ "--no-default-features", "--all-features" ]
     runs-on: ${{ matrix.os }}
-
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build crate for host OS
-        run: cargo build --features critical-section-single-hart
+        run: cargo build ${{ matrix.cargo_flags }}

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -1,14 +1,10 @@
-name: Clippy
-
 on:
   push:
     branches: [ staging, trying, master ]
   pull_request:
-    branches: [ master ]
+  merge_group:
 
-defaults:
-  run:
-    shell: bash
+name: Clippy lints
 
 env:
   CLIPPY_PARAMS: -W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo
@@ -16,21 +12,22 @@ env:
 jobs:
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        toolchain: [ stable, nightly ]
         cargo_flags:
           - "--no-default-features"
           - "--all-features"
+        include:
+          # Nightly is only for reference and allowed to fail
+          - toolchain: nightly
+            experimental: true
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
         with:
-          toolchain: stable
           components: clippy
-
       - name: Run clippy
         run: cargo clippy --all ${{ matrix.cargo_flags }} -- -D warnings

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -26,8 +26,9 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: Run clippy
         run: cargo clippy --all ${{ matrix.cargo_flags }} -- -D warnings

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -31,3 +31,12 @@ jobs:
           components: clippy
       - name: Run clippy
         run: cargo clippy --all ${{ matrix.cargo_flags }} -- -D warnings
+
+    # Job to check that all the lint checks succeeded
+    clippy-check:
+    needs:
+    - clippy
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all ${{ matrix.cargo_flags }} -- -D warnings
 
-    # Job to check that all the lint checks succeeded
-    clippy-check:
+   # Job to check that all the lint checks succeeded
+  clippy-check:
     needs:
     - clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -4,14 +4,13 @@ on:
   pull_request:
   merge_group:
 
-name: Clippy lints
+name: Lints compliance check
 
 env:
   CLIPPY_PARAMS: -W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo
 
 jobs:
   clippy:
-    name: Clippy
     strategy:
       matrix:
         toolchain: [ stable, nightly ]

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -7,8 +7,7 @@ on:
 name: Code formatting check
 
 jobs:
-  fmt:
-    name: Rustfmt
+  rustfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -1,4 +1,3 @@
-
 on:
   push:
     branches: [ staging, trying, master ]
@@ -9,16 +8,11 @@ name: Code formatting check
 jobs:
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Run Rustfmt
+        run: cargo fmt --all -- --check --verbose

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [ staging, trying, master ]
   pull_request:
+  merge_group:
 
 name: Code formatting check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `asm::fence()`, a wrapper for implementing a `fence` instruction
 - Add `asm::fence_i()`, a wrapper for implementing a `fence.i` instruction
 
+### Changed
+
+- CI action updated. It now uses `checkout@v3` and `dtolenay/rust-toolchain`.
+
 ## [v0.10.1] - 2023-01-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- CI action updated. It now uses `checkout@v3` and `dtolenay/rust-toolchain`.
+- CI actions updated. They now use `checkout@v3` and `dtolnay/rust-toolchain`.
 
 ## [v0.10.1] - 2023-01-18
 


### PR DESCRIPTION
With all the bors thing going on, I've been reading a bit about merge queues etc. and noticed that some of our workflows still use outdated/deprecated actions. This PR fixes this.