### PR TITLE
Remove bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,8 +1,0 @@
-block_labels = ["needs-decision"]
-delete_merged_branches = true
-required_approvals = 1
-status = [
-    "build-check",
-    "clippy-check",
-    "rustfmt",
-]


### PR DESCRIPTION
Once we have the CI workflows updated and ready for GHMQ... it's time to remove all the bors-related files and configurations. Once this PR is accepted, bors will no longer be required and we can remove it from the repo settings once and for all.

Related PRs and issues: #132 #133 
Check also [this issue](https://github.com/rust-embedded/wg/issues/671) of the wg repo.