### PR TITLE
Remove bit_field dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 target/
 
 .vscode/
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Removed `bit_field` dependency
 - CI actions updated. They now use `checkout@v3` and `dtolnay/rust-toolchain`.
 - `mcause::{Interrupt, Exception}` and `scause::{Interrupt, Exception}` now implement `From` trait for `usize`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ critical-section-single-hart = ["critical-section/restore-state-bool"]
 plic = ["volatile-register"]
 
 [dependencies]
-bit_field = "0.10.0"
 critical-section = "1.1.0"
 embedded-hal = "0.2.6"
 volatile-register = {version  = "0.2.1", optional = true}

--- a/src/register/fcsr.rs
+++ b/src/register/fcsr.rs
@@ -1,7 +1,5 @@
 //! Floating-point control and status register
 
-use bit_field::BitField;
-
 /// Floating-point control and status register
 #[derive(Clone, Copy, Debug)]
 pub struct FCSR {
@@ -35,31 +33,31 @@ impl Flags {
     /// Inexact
     #[inline]
     pub fn nx(&self) -> bool {
-        self.0.get_bit(0)
+        self.0 & (1 << 0) != 0
     }
 
     /// Underflow
     #[inline]
     pub fn uf(&self) -> bool {
-        self.0.get_bit(1)
+        self.0 & (1 << 1) != 0
     }
 
     /// Overflow
     #[inline]
     pub fn of(&self) -> bool {
-        self.0.get_bit(2)
+        self.0 & (1 << 2) != 0
     }
 
     /// Divide by Zero
     #[inline]
     pub fn dz(&self) -> bool {
-        self.0.get_bit(3)
+        self.0 & (1 << 3) != 0
     }
 
     /// Invalid Operation
     #[inline]
     pub fn nv(&self) -> bool {
-        self.0.get_bit(4)
+        self.0 & (1 << 4) != 0
     }
 }
 
@@ -84,13 +82,14 @@ impl FCSR {
     /// Accrued Exception Flags
     #[inline]
     pub fn fflags(&self) -> Flags {
-        Flags(self.bits.get_bits(0..5))
+        Flags(self.bits & 0x1F) // bits 0-4
     }
 
     /// Rounding Mode
     #[inline]
     pub fn frm(&self) -> RoundingMode {
-        match self.bits.get_bits(5..8) {
+        let frm = (self.bits >> 5) & 0x7; // bits 5-7
+        match frm {
             0b000 => RoundingMode::RoundToNearestEven,
             0b001 => RoundingMode::RoundTowardsZero,
             0b010 => RoundingMode::RoundDown,

--- a/src/register/macros.rs
+++ b/src/register/macros.rs
@@ -229,8 +229,9 @@ macro_rules! set_pmp {
             assert!(index < 8);
 
             let mut value = _read();
+            value &= !(0xFF << (8 * index)); // clear previous value
             let byte = (locked as usize) << 7 | (range as usize) << 3 | (permission as usize);
-            value.set_bits(8 * index..=8 * index + 7, byte);
+            value |= byte << (8 * index);
             _write(value);
         }
     };
@@ -248,7 +249,7 @@ macro_rules! clear_pmp {
             assert!(index < 8);
 
             let mut value = _read();
-            value.set_bits(8 * index..=8 * index + 7, 0);
+            value &= !(0xFF << (8 * index)); // clear previous value
             _write(value);
         }
     };

--- a/src/register/mcounteren.rs
+++ b/src/register/mcounteren.rs
@@ -1,7 +1,5 @@
 //! mcounteren register
 
-use bit_field::BitField;
-
 /// mcounteren register
 #[derive(Clone, Copy, Debug)]
 pub struct Mcounteren {
@@ -12,26 +10,26 @@ impl Mcounteren {
     /// Supervisor "cycle\[h\]" Enable
     #[inline]
     pub fn cy(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Supervisor "time\[h\]" Enable
     #[inline]
     pub fn tm(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// Supervisor "instret\[h\]" Enable
     #[inline]
     pub fn ir(&self) -> bool {
-        self.bits.get_bit(2)
+        self.bits & (1 << 2) != 0
     }
 
     /// Supervisor "hpm\[x\]" Enable (bits 3-31)
     #[inline]
     pub fn hpm(&self, index: usize) -> bool {
         assert!((3..32).contains(&index));
-        self.bits.get_bit(index)
+        self.bits & (1 << index) != 0
     }
 }
 

--- a/src/register/medeleg.rs
+++ b/src/register/medeleg.rs
@@ -1,7 +1,5 @@
 //! medeleg register
 
-use bit_field::BitField;
-
 /// medeleg register
 #[derive(Clone, Copy, Debug)]
 pub struct Medeleg {
@@ -18,85 +16,85 @@ impl Medeleg {
     /// Instruction Address Misaligned Delegate
     #[inline]
     pub fn instruction_misaligned(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Instruction Access Fault Delegate
     #[inline]
     pub fn instruction_fault(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// Illegal Instruction Delegate
     #[inline]
     pub fn illegal_instruction(&self) -> bool {
-        self.bits.get_bit(2)
+        self.bits & (1 << 2) != 0
     }
 
     /// Breakpoint Delegate
     #[inline]
     pub fn breakpoint(&self) -> bool {
-        self.bits.get_bit(3)
+        self.bits & (1 << 3) != 0
     }
 
     /// Load Address Misaligned Delegate
     #[inline]
     pub fn load_misaligned(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// Load Access Fault Delegate
     #[inline]
     pub fn load_fault(&self) -> bool {
-        self.bits.get_bit(5)
+        self.bits & (1 << 5) != 0
     }
 
     /// Store/AMO Address Misaligned Delegate
     #[inline]
     pub fn store_misaligned(&self) -> bool {
-        self.bits.get_bit(6)
+        self.bits & (1 << 6) != 0
     }
 
     /// Store/AMO Access Fault Delegate
     #[inline]
     pub fn store_fault(&self) -> bool {
-        self.bits.get_bit(7)
+        self.bits & (1 << 7) != 0
     }
 
     /// Environment Call from U-mode Delegate
     #[inline]
     pub fn user_env_call(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 
     /// Environment Call from S-mode Delegate
     #[inline]
     pub fn supervisor_env_call(&self) -> bool {
-        self.bits.get_bit(9)
+        self.bits & (1 << 9) != 0
     }
 
     /// Environment Call from M-mode Delegate
     #[inline]
     pub fn machine_env_call(&self) -> bool {
-        self.bits.get_bit(11)
+        self.bits & (1 << 11) != 0
     }
 
     /// Instruction Page Fault Delegate
     #[inline]
     pub fn instruction_page_fault(&self) -> bool {
-        self.bits.get_bit(12)
+        self.bits & (1 << 12) != 0
     }
 
     /// Load Page Fault Delegate
     #[inline]
     pub fn load_page_fault(&self) -> bool {
-        self.bits.get_bit(13)
+        self.bits & (1 << 13) != 0
     }
 
     /// Store/AMO Page Fault Delegate
     #[inline]
     pub fn store_page_fault(&self) -> bool {
-        self.bits.get_bit(15)
+        self.bits & (1 << 15) != 0
     }
 }
 

--- a/src/register/mideleg.rs
+++ b/src/register/mideleg.rs
@@ -1,7 +1,5 @@
 //! mideleg register
 
-use bit_field::BitField;
-
 /// mideleg register
 #[derive(Clone, Copy, Debug)]
 pub struct Mideleg {
@@ -18,37 +16,37 @@ impl Mideleg {
     /// User Software Interrupt Delegate
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Supervisor Software Interrupt Delegate
     #[inline]
     pub fn ssoft(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// User Timer Interrupt Delegate
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// Supervisor Timer Interrupt Delegate
     #[inline]
     pub fn stimer(&self) -> bool {
-        self.bits.get_bit(5)
+        self.bits & (1 << 5) != 0
     }
 
     /// User External Interrupt Delegate
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 
     /// Supervisor External Interrupt Delegate
     #[inline]
     pub fn sext(&self) -> bool {
-        self.bits.get_bit(9)
+        self.bits & (1 << 9) != 0
     }
 }
 

--- a/src/register/mie.rs
+++ b/src/register/mie.rs
@@ -1,7 +1,5 @@
 //! mie register
 
-use bit_field::BitField;
-
 /// mie register
 #[derive(Clone, Copy, Debug)]
 pub struct Mie {
@@ -18,55 +16,55 @@ impl Mie {
     /// User Software Interrupt Enable
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Supervisor Software Interrupt Enable
     #[inline]
     pub fn ssoft(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// Machine Software Interrupt Enable
     #[inline]
     pub fn msoft(&self) -> bool {
-        self.bits.get_bit(3)
+        self.bits & (1 << 3) != 0
     }
 
     /// User Timer Interrupt Enable
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// Supervisor Timer Interrupt Enable
     #[inline]
     pub fn stimer(&self) -> bool {
-        self.bits.get_bit(5)
+        self.bits & (1 << 5) != 0
     }
 
     /// Machine Timer Interrupt Enable
     #[inline]
     pub fn mtimer(&self) -> bool {
-        self.bits.get_bit(7)
+        self.bits & (1 << 7) != 0
     }
 
     /// User External Interrupt Enable
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 
     /// Supervisor External Interrupt Enable
     #[inline]
     pub fn sext(&self) -> bool {
-        self.bits.get_bit(9)
+        self.bits & (1 << 9) != 0
     }
 
     /// Machine External Interrupt Enable
     #[inline]
     pub fn mext(&self) -> bool {
-        self.bits.get_bit(11)
+        self.bits & (1 << 11) != 0
     }
 }
 

--- a/src/register/mip.rs
+++ b/src/register/mip.rs
@@ -1,7 +1,5 @@
 //! mip register
 
-use bit_field::BitField;
-
 /// mip register
 #[derive(Clone, Copy, Debug)]
 pub struct Mip {
@@ -18,55 +16,55 @@ impl Mip {
     /// User Software Interrupt Pending
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Supervisor Software Interrupt Pending
     #[inline]
     pub fn ssoft(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// Machine Software Interrupt Pending
     #[inline]
     pub fn msoft(&self) -> bool {
-        self.bits.get_bit(3)
+        self.bits & (1 << 3) != 0
     }
 
     /// User Timer Interrupt Pending
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// Supervisor Timer Interrupt Pending
     #[inline]
     pub fn stimer(&self) -> bool {
-        self.bits.get_bit(5)
+        self.bits & (1 << 5) != 0
     }
 
     /// Machine Timer Interrupt Pending
     #[inline]
     pub fn mtimer(&self) -> bool {
-        self.bits.get_bit(7)
+        self.bits & (1 << 7) != 0
     }
 
     /// User External Interrupt Pending
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 
     /// Supervisor External Interrupt Pending
     #[inline]
     pub fn sext(&self) -> bool {
-        self.bits.get_bit(9)
+        self.bits & (1 << 9) != 0
     }
 
     /// Machine External Interrupt Pending
     #[inline]
     pub fn mext(&self) -> bool {
-        self.bits.get_bit(11)
+        self.bits & (1 << 11) != 0
     }
 }
 

--- a/src/register/scounteren.rs
+++ b/src/register/scounteren.rs
@@ -1,7 +1,5 @@
 //! scounteren register
 
-use bit_field::BitField;
-
 /// scounteren register
 #[derive(Clone, Copy, Debug)]
 pub struct Scounteren {
@@ -12,26 +10,26 @@ impl Scounteren {
     /// User "cycle\[h\]" Enable
     #[inline]
     pub fn cy(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// User "time\[h\]" Enable
     #[inline]
     pub fn tm(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// User "instret\[h]\" Enable
     #[inline]
     pub fn ir(&self) -> bool {
-        self.bits.get_bit(2)
+        self.bits & (1 << 2) != 0
     }
 
     /// User "hpm\[x\]" Enable (bits 3-31)
     #[inline]
     pub fn hpm(&self, index: usize) -> bool {
         assert!((3..32).contains(&index));
-        self.bits.get_bit(index)
+        self.bits & (1 << index) != 0
     }
 }
 

--- a/src/register/sie.rs
+++ b/src/register/sie.rs
@@ -1,7 +1,5 @@
 //! sie register
 
-use bit_field::BitField;
-
 /// sie register
 #[derive(Clone, Copy, Debug)]
 pub struct Sie {
@@ -18,37 +16,37 @@ impl Sie {
     /// User Software Interrupt Enable
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Supervisor Software Interrupt Enable
     #[inline]
     pub fn ssoft(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// User Timer Interrupt Enable
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// Supervisor Timer Interrupt Enable
     #[inline]
     pub fn stimer(&self) -> bool {
-        self.bits.get_bit(5)
+        self.bits & (1 << 5) != 0
     }
 
     /// User External Interrupt Enable
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 
     /// Supervisor External Interrupt Enable
     #[inline]
     pub fn sext(&self) -> bool {
-        self.bits.get_bit(9)
+        self.bits & (1 << 9) != 0
     }
 }
 

--- a/src/register/sip.rs
+++ b/src/register/sip.rs
@@ -1,7 +1,5 @@
 //! sip register
 
-use bit_field::BitField;
-
 /// sip register
 #[derive(Clone, Copy, Debug)]
 pub struct Sip {
@@ -18,37 +16,37 @@ impl Sip {
     /// User Software Interrupt Pending
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// Supervisor Software Interrupt Pending
     #[inline]
     pub fn ssoft(&self) -> bool {
-        self.bits.get_bit(1)
+        self.bits & (1 << 1) != 0
     }
 
     /// User Timer Interrupt Pending
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// Supervisor Timer Interrupt Pending
     #[inline]
     pub fn stimer(&self) -> bool {
-        self.bits.get_bit(5)
+        self.bits & (1 << 5) != 0
     }
 
     /// User External Interrupt Pending
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 
     /// Supervisor External Interrupt Pending
     #[inline]
     pub fn sext(&self) -> bool {
-        self.bits.get_bit(9)
+        self.bits & (1 << 9) != 0
     }
 }
 

--- a/src/register/uie.rs
+++ b/src/register/uie.rs
@@ -1,7 +1,5 @@
 //! uie register
 
-use bit_field::BitField;
-
 /// uie register
 #[derive(Clone, Copy, Debug)]
 pub struct Uie {
@@ -18,19 +16,19 @@ impl Uie {
     /// User Software Interrupt Enable
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// User Timer Interrupt Enable
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// User External Interrupt Enable
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 }
 

--- a/src/register/uip.rs
+++ b/src/register/uip.rs
@@ -1,7 +1,5 @@
 //! uip register
 
-use bit_field::BitField;
-
 /// uip register
 #[derive(Clone, Copy, Debug)]
 pub struct Uip {
@@ -18,19 +16,19 @@ impl Uip {
     /// User Software Interrupt Pending
     #[inline]
     pub fn usoft(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// User Timer Interrupt Pending
     #[inline]
     pub fn utimer(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 
     /// User External Interrupt Pending
     #[inline]
     pub fn uext(&self) -> bool {
-        self.bits.get_bit(8)
+        self.bits & (1 << 8) != 0
     }
 }
 

--- a/src/register/ustatus.rs
+++ b/src/register/ustatus.rs
@@ -1,8 +1,6 @@
 //! ustatus register
 // TODO: Virtualization, Memory Privilege and Extension Context Fields
 
-use bit_field::BitField;
-
 /// ustatus register
 #[derive(Clone, Copy, Debug)]
 pub struct Ustatus {
@@ -13,13 +11,13 @@ impl Ustatus {
     /// User Interrupt Enable
     #[inline]
     pub fn uie(&self) -> bool {
-        self.bits.get_bit(0)
+        self.bits & (1 << 0) != 0
     }
 
     /// User Previous Interrupt Enable
     #[inline]
     pub fn upie(&self) -> bool {
-        self.bits.get_bit(4)
+        self.bits & (1 << 4) != 0
     }
 }
 


### PR DESCRIPTION
I replaced the `bit_field` crate with bit-wise operations. In this way, we avoid needless checks for getting bits from the registers. Now, future versions of the `riscv` crate will be slightly faster (and smaller)