### PR TITLE
asm: set unsafety of `nop` and `delay` functions to safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - CI actions updated. They now use `checkout@v3` and `dtolnay/rust-toolchain`.
 - `mcause::{Interrupt, Exception}` and `scause::{Interrupt, Exception}` now implement `From` trait for `usize`
+- Set safety of `asm::nop` and `asm::delay` functions to safe.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ plic = ["volatile-register"]
 bit_field = "0.10.0"
 critical-section = "1.1.0"
 embedded-hal = "0.2.6"
-volatile-register = {version  = "0.2.1", optional = true}
+volatile-register = { version  = "0.2.1", optional = true }


### PR DESCRIPTION
The NOP instruction does not change architecturally visible state, including operations that would break memory safety boundaries; thus `nop` instruction wrapper should be safe to call. The `delay` function uses ADDI and BNE instructions which would form a function internal loop, which is safe under Rust constraints.

This pull request also includes an explanation on NOP instruction under Rust docs, and a small codestyle fix in Cargo.toml file.

I modified internal macro `instruction` to allow wrapping instruction with safe functions. If it's inappropriate, please reply and I'll change to other ways of implementation.