### PR TITLE
Update embedded-hal to 1.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # All generated code should be running on stable now, MRSV is 1.59.0
-        toolchain: [ stable, nightly, 1.59.0 ]
+        toolchain: [ stable, nightly, 1.60.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Update `embedded-hal` dependency to v1.0 (bumps MSRV to 1.60)
 - `misa::MXL` renamed to `misa::XLEN`
 - Removed `bit_field` dependency
 - CI actions updated. They now use `checkout@v3` and `dtolnay/rust-toolchain`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ targets = [
 critical-section-single-hart = ["critical-section/restore-state-bool"]
 
 [dependencies]
-critical-section = "1.1.0"
-embedded-hal = "0.2.6"
+critical-section = "1.1.2"
+embedded-hal = "1.0.0-rc.1"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.59 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,87 +1,30 @@
 //! Delay devices and providers
 use crate::register::mcycle;
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::delay::DelayUs;
 
 /// Machine mode cycle counter (`mcycle`) as a delay provider
 #[derive(Copy, Clone)]
+#[repr(transparent)]
 pub struct McycleDelay {
+    /// The clock speed of the core, in Hertz
     ticks_second: u32,
 }
 
 impl McycleDelay {
     /// Constructs the delay provider.
     /// `ticks_second` should be the clock speed of the core, in Hertz
-    #[inline(always)]
-    pub fn new(ticks_second: u32) -> Self {
+    #[inline]
+    pub const fn new(ticks_second: u32) -> Self {
         Self { ticks_second }
     }
 }
 
-impl DelayUs<u64> for McycleDelay {
+impl DelayUs for McycleDelay {
     #[inline]
-    fn delay_us(&mut self, us: u64) {
-        let t0 = mcycle::read64();
-        let clock = (us * (self.ticks_second as u64)) / 1_000_000;
-        while mcycle::read64().wrapping_sub(t0) <= clock {}
-    }
-}
-
-impl DelayUs<u32> for McycleDelay {
-    #[inline(always)]
     fn delay_us(&mut self, us: u32) {
-        self.delay_us(us as u64)
-    }
-}
-
-// Implemented for constructions like `delay.delay_us(50_000);`
-impl DelayUs<i32> for McycleDelay {
-    #[inline(always)]
-    fn delay_us(&mut self, us: i32) {
-        assert!(us >= 0);
-        self.delay_us(us as u32);
-    }
-}
-
-impl DelayUs<u16> for McycleDelay {
-    #[inline(always)]
-    fn delay_us(&mut self, us: u16) {
-        self.delay_us(us as u32)
-    }
-}
-
-impl DelayUs<u8> for McycleDelay {
-    #[inline(always)]
-    fn delay_us(&mut self, us: u8) {
-        self.delay_us(us as u32)
-    }
-}
-
-impl DelayMs<u32> for McycleDelay {
-    #[inline]
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay_us((ms as u64) * 1000)
-    }
-}
-
-// Implemented for constructions like `delay.delay_ms(50_000);`
-impl DelayMs<i32> for McycleDelay {
-    #[inline(always)]
-    fn delay_ms(&mut self, ms: i32) {
-        assert!(ms >= 0);
-        self.delay_ms(ms as u32);
-    }
-}
-
-impl DelayMs<u16> for McycleDelay {
-    #[inline(always)]
-    fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(ms as u32)
-    }
-}
-
-impl DelayMs<u8> for McycleDelay {
-    #[inline(always)]
-    fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(ms as u32)
+        let t0 = mcycle::read64();
+        let us_64: u64 = us.into();
+        let clock = (us_64 * (self.ticks_second as u64)) / 1_000_000u64;
+        while mcycle::read64().wrapping_sub(t0) <= clock {}
     }
 }


### PR DESCRIPTION
Preparing to support `e-h-1` once we get the first stable version.

Related: #96 and #106 