### PR TITLE
Update for embedded-hal to 1.0.0-rc.2

### DIFF
--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.59.0
-        toolchain: [ stable, nightly, 1.59.0 ]
+        # All generated code should be running on stable now, MRSV is 1.60.0
+        toolchain: [ stable, nightly, 1.60.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf
@@ -41,7 +41,7 @@ jobs:
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=single-hart
       - name: Build example (all features)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --all-features
-  
+
   # Job to check that all the builds succeeded
   build-check:
     needs:

--- a/.github/workflows/riscv.yaml
+++ b/.github/workflows/riscv.yaml
@@ -11,7 +11,7 @@ jobs:
   build-riscv:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.59.0
+        # All generated code should be running on stable now, MRSV is 1.60.0
         toolchain: [ stable, nightly, 1.60.0 ]
         target:
           - riscv32i-unknown-none-elf
@@ -35,7 +35,7 @@ jobs:
       run: cargo build --package riscv --target ${{ matrix.target }}
     - name: Build (all features)
       run: cargo build --package riscv --target ${{ matrix.target }} --all-features
-      
+
   # On MacOS, Ubuntu, and Windows, we at least make sure that the crate builds and links.
   build-others:
     strategy:
@@ -49,7 +49,7 @@ jobs:
         run: cargo build --package riscv
       - name: Build (all features)
         run: cargo build --package riscv --all-features
-  
+
   # Job to check that all the builds succeeded
   build-check:
     needs:

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Upgrade rust-version to 1.60
 - Cargo workspace for riscv and riscv-rt
 - Use inline assembly instead of pre-compiled blobs
 - Removed bors in favor of GitHub Merge Queue

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "riscv-rt"
 version = "0.11.0"
-rust-version = "1.59"
+rust-version = "1.60"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]

--- a/riscv-rt/README.md
+++ b/riscv-rt/README.md
@@ -11,7 +11,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.59 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.59 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 //!
 //! # Features
@@ -483,14 +483,14 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
             	sd      {a},0({start})
             	addi    {start},{start},8
             	bltu    {start},{end},1b
-            
+
             2: // .data zero registers
                 li      {a},0
                 li      {input},0
 
             	la      {start},_sbss
             	la      {end},_ebss
-            
+
                 bgeu    {start},{end},4f
 
             3: // .bss main loop

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Cargo workspace for riscv and riscv-rt
-- Update `embedded-hal` dependency to v1.0 (bumps MSRV to 1.60)
+- Update `embedded-hal` dependency to v1.0.0-rc.2 (bumps MSRV to 1.60)
 - `misa::MXL` renamed to `misa::XLEN`
 - Removed `bit_field` dependency
 - CI actions updated. They now use `checkout@v3` and `dtolnay/rust-toolchain`.

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -2,7 +2,7 @@
 name = "riscv"
 version = "0.10.1"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "hardware-support", "no-std"]

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -24,4 +24,4 @@ critical-section-single-hart = ["critical-section/restore-state-bool"]
 
 [dependencies]
 critical-section = "1.1.2"
-embedded-hal = "1.0.0-rc.1"
+embedded-hal = "1.0.0-rc.2"

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -24,4 +24,4 @@ critical-section-single-hart = ["critical-section/restore-state-bool"]
 
 [dependencies]
 critical-section = "1.1.2"
-embedded-hal = "=1.0.0-rc.1"
+embedded-hal = "1.0.0-rc.1"

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -24,4 +24,4 @@ critical-section-single-hart = ["critical-section/restore-state-bool"]
 
 [dependencies]
 critical-section = "1.1.2"
-embedded-hal = "1.0.0-rc.1"
+embedded-hal = "=1.0.0-rc.1"

--- a/riscv/src/delay.rs
+++ b/riscv/src/delay.rs
@@ -28,8 +28,8 @@ impl DelayNs for McycleDelay {
     #[inline]
    fn delay_ns(&mut self, ns: u32) {
         let t0 = mcycle::read64();
-        let us_64: u64 = ns.into();
-        let clock = (us_64 * (self.ticks_second as u64)) / 1_000_000_000u64;
+        let ns_64: u64 = ns.into();
+        let clock = (ns_64 * (self.ticks_second as u64)) / 1_000_000_000u64;
         while mcycle::read64().wrapping_sub(t0) <= clock {}
    }
 }

--- a/riscv/src/delay.rs
+++ b/riscv/src/delay.rs
@@ -1,6 +1,6 @@
 //! Delay devices and providers
 use crate::register::mcycle;
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 /// Machine mode cycle counter (`mcycle`) as a delay provider
 #[derive(Copy, Clone)]
@@ -19,12 +19,17 @@ impl McycleDelay {
     }
 }
 
-impl DelayUs for McycleDelay {
+impl DelayNs for McycleDelay {
     #[inline]
     fn delay_us(&mut self, us: u32) {
-        let t0 = mcycle::read64();
-        let us_64: u64 = us.into();
-        let clock = (us_64 * (self.ticks_second as u64)) / 1_000_000u64;
-        while mcycle::read64().wrapping_sub(t0) <= clock {}
+	self.delay_ns(us * 1000)
     }
+
+    #[inline]
+   fn delay_ns(&mut self, ns: u32) {
+        let t0 = mcycle::read64();
+        let us_64: u64 = ns.into();
+        let clock = (us_64 * (self.ticks_second as u64)) / 1_000_000_000u64;
+        while mcycle::read64().wrapping_sub(t0) <= clock {}
+   }
 }

--- a/riscv/src/delay.rs
+++ b/riscv/src/delay.rs
@@ -21,11 +21,6 @@ impl McycleDelay {
 
 impl DelayNs for McycleDelay {
     #[inline]
-    fn delay_us(&mut self, us: u32) {
-	self.delay_ns(us * 1000)
-    }
-
-    #[inline]
    fn delay_ns(&mut self, ns: u32) {
         let t0 = mcycle::read64();
         let ns_64: u64 = ns.into();

--- a/riscv/src/delay.rs
+++ b/riscv/src/delay.rs
@@ -21,10 +21,10 @@ impl McycleDelay {
 
 impl DelayNs for McycleDelay {
     #[inline]
-   fn delay_ns(&mut self, ns: u32) {
+    fn delay_ns(&mut self, ns: u32) {
         let t0 = mcycle::read64();
         let ns_64: u64 = ns.into();
         let clock = (ns_64 * (self.ticks_second as u64)) / 1_000_000_000u64;
         while mcycle::read64().wrapping_sub(t0) <= clock {}
-   }
+    }
 }

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.59 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 //!
 //! # Features


### PR DESCRIPTION
embedded-hal 1.0.0-rc.2 introduced [backwards incompatible changes](https://github.com/rust-embedded/embedded-hal/commit/4ec58c85d81a191a0efddcf7269d0a4c753b2b45) that break riscv builds.  This change pins the crate to 1.0.0-rc.1.

```
error[E0432]: unresolved import `embedded_hal::delay::DelayUs`
 --> riscv/src/delay.rs:3:5
  |
3 | use embedded_hal::delay::DelayUs;
  |     ^^^^^^^^^^^^^^^^^^^^^-------
  |     |                    |
  |     |                    help: a similar name exists in the module: `DelayNs`
  |     no `DelayUs` in `delay`

For more information about this error, try `rustc --explain E0432`.
```