### PR TITLE
`riscv-rt`: remove riscv-target

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Removed riscv-target dependency for build
 - Cargo workspace for riscv and riscv-rt
 - Use inline assembly instead of pre-compiled blobs
 - Removed bors in favor of GitHub Merge Queue

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -21,6 +21,3 @@ riscv-rt-macros = { path = "macros", version = "0.2.0" }
 
 [dev-dependencies]
 panic-halt = "0.2.0"
-
-[build-dependencies]
-riscv-target = "0.1.2"


### PR DESCRIPTION
I implemented the `riscv-target` necessary logic in `build.rs`. This way we avoid extra dependencies that triggered problems with the MSRV (see #159).