### PR TITLE
`riscv-rt`: Implement FPU initialization

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add FPU initialization
 - New GitHub workflow for checking invalid labels in PRs
 - New GitHub workflow for checking modifications on CHANGELOG.md
 - New GitHub workflow for checking clippy lints in PRs

--- a/riscv-rt/build.rs
+++ b/riscv-rt/build.rs
@@ -46,18 +46,25 @@ fn parse_target(target: &str, cargo_flags: &str) -> (u32, HashSet<char>) {
     let cargo_flags = cargo_flags
         .split(0x1fu8 as char)
         .filter(|arg| !arg.is_empty());
-     
+
     cargo_flags
-        .filter(|k| k.starts_with("target-feature=")).flat_map(|str| {
+        .filter(|k| k.starts_with("target-feature="))
+        .flat_map(|str| {
             let flags = str.split('=').collect::<Vec<&str>>()[1];
             flags.split(',')
         })
         .for_each(|feature| {
             let chars = feature.chars().collect::<Vec<char>>();
             match chars[0] {
-                '+' => { extensions.insert(chars[1]); }
-                '-' => { extensions.remove(&chars[1]); }
-                _ => { panic!("Unsupported target feature operation"); }
+                '+' => {
+                    extensions.insert(chars[1]);
+                }
+                '-' => {
+                    extensions.remove(&chars[1]);
+                }
+                _ => {
+                    panic!("Unsupported target feature operation");
+                }
             }
         });
 
@@ -73,7 +80,7 @@ fn main() {
     if target.starts_with("riscv") {
         println!("cargo:rustc-cfg=riscv");
 
-        // This is required until target_arch & target_feature risc-v work is 
+        // This is required until target_arch & target_feature risc-v work is
         // stable and in-use (rust 1.75.0)
         let (bits, extensions) = parse_target(&target, &cargo_flags);
 

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -224,6 +224,25 @@ impl Parse for AsmLoopArgs {
     }
 }
 
+/// Loops an asm expression n times.
+///
+/// `loop_asm!` takes 2 arguments, the first is a string literal and the second is a number literal
+/// See [the formatting syntax documentation in `std::fmt`](../std/fmt/index.html)
+/// for details.
+///
+/// Argument 1 is an assembly expression, all "{}" in this assembly expression will be replaced with the 
+/// current loop index.
+/// 
+/// Argument 2 is the number of loops to do with the provided expression.
+///
+/// # Examples
+///
+/// ```
+/// # use riscv_rt_macros::loop_asm;
+/// unsafe {
+///     loop_asm!("fmv.w.x f{}, x0", 32); // => core::arch::asm!("fmv.w.x f0, x0") ... core::arch::asm!("fmv.w.x f31, x0")
+/// }
+/// ```
 #[proc_macro]
 pub fn loop_asm(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as AsmLoopArgs);

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -9,7 +9,11 @@ extern crate proc_macro2;
 extern crate syn;
 
 use proc_macro2::Span;
-use syn::{parse::{self, Parse}, spanned::Spanned, FnArg, ItemFn, PathArguments, ReturnType, Type, Visibility, LitStr, LitInt};
+use syn::{
+    parse::{self, Parse},
+    spanned::Spanned,
+    FnArg, ItemFn, LitInt, LitStr, PathArguments, ReturnType, Type, Visibility,
+};
 
 use proc_macro::TokenStream;
 
@@ -230,9 +234,9 @@ impl Parse for AsmLoopArgs {
 /// See [the formatting syntax documentation in `std::fmt`](../std/fmt/index.html)
 /// for details.
 ///
-/// Argument 1 is an assembly expression, all "{}" in this assembly expression will be replaced with the 
+/// Argument 1 is an assembly expression, all "{}" in this assembly expression will be replaced with the
 /// current loop index.
-/// 
+///
 /// Argument 2 is the number of loops to do with the provided expression.
 ///
 /// # Examples
@@ -247,10 +251,13 @@ impl Parse for AsmLoopArgs {
 pub fn loop_asm(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as AsmLoopArgs);
 
-    let tokens = (0..args.count).map(|i| {
-        let i = i.to_string();
-        let asm = args.asm_template.replace("{}", &i);
-        format!("core::arch::asm!(\"{}\");", asm)
-    }).collect::<Vec<String>>().join("\n");
+    let tokens = (0..args.count)
+        .map(|i| {
+            let i = i.to_string();
+            let asm = args.asm_template.replace("{}", &i);
+            format!("core::arch::asm!(\"{}\");", asm)
+        })
+        .collect::<Vec<String>>()
+        .join("\n");
     tokens.parse().unwrap()
 }

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -525,8 +525,8 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
 
         // Zero out floating point registers
         if cfg!(all(target_arch = "riscv32", riscvd)) {
-            // rv32 targets with double precision floating point can use fmvp.d.x 
-            // to combine 2 32 bit registers to fill the 64 bit floating point 
+            // rv32 targets with double precision floating point can use fmvp.d.x
+            // to combine 2 32 bit registers to fill the 64 bit floating point
             // register
             riscv_rt_macros::loop_asm!("fmvp.d.x f{}, x0, x0", 32);
         } else if cfg!(riscvd) {

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -524,17 +524,15 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
         core::arch::asm!("fscsr x0"); // Zero out fcsr register csrrw x0, fcsr, x0
 
         // Zero out floating point registers
-        for i in 0..32 { 
-            if cfg!(all(riscv32, riscvd)) {
-                // rv32 targets with double precision floating point can use fmvp.d.x 
-                // to combine 2 32 bit registers to fill the 64 bit floating point 
-                // register
-                core::arch::asm!("fmvp.d.x f{}, x0, x0", i);
-            } else if cfg!(riscvd) {
-                core::arch::asm!("fmv.d.x f{}, x0", i);
-            } else {
-                core::arch::asm!("fmv.w.x f{}, x0", i);
-            }
+        if cfg!(all(target_arch = "riscv32", riscvd)) {
+            // rv32 targets with double precision floating point can use fmvp.d.x 
+            // to combine 2 32 bit registers to fill the 64 bit floating point 
+            // register
+            riscv_rt_macros::loop_asm!("fmvp.d.x f{}, x0, x0", 32);
+        } else if cfg!(riscvd) {
+            riscv_rt_macros::loop_asm!("fmv.d.x f{}, x0", 32);
+        } else {
+            riscv_rt_macros::loop_asm!("fmv.w.x f{}, x0", 32);
         }
     }
 

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -524,16 +524,14 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
         core::arch::asm!("fscsr x0"); // Zero out fcsr register csrrw x0, fcsr, x0
 
         // Zero out floating point registers
-        if cfg!(all(target_arch = "riscv32", riscvd)) {
-            // rv32 targets with double precision floating point can use fmvp.d.x
-            // to combine 2 32 bit registers to fill the 64 bit floating point
-            // register
-            riscv_rt_macros::loop_asm!("fmvp.d.x f{}, x0, x0", 32);
-        } else if cfg!(riscvd) {
-            riscv_rt_macros::loop_asm!("fmv.d.x f{}, x0", 32);
-        } else {
-            riscv_rt_macros::loop_asm!("fmv.w.x f{}, x0", 32);
-        }
+        #[cfg(all(target_arch = "riscv32", riscvd))]
+        riscv_rt_macros::loop_asm!("fcvt.d.w f{}, x0", 32);
+
+        #[cfg(all(target_arch = "riscv64", riscvd))]
+        riscv_rt_macros::loop_asm!("fmv.d.x f{}, x0", 32);
+
+        #[cfg(not(riscvd))]
+        riscv_rt_macros::loop_asm!("fmv.w.x f{}, x0", 32);
     }
 
     _setup_interrupts();


### PR DESCRIPTION
This PR adds FPU initialization when compiling with the `f` or `d` extensions, for the implementation of this I have updated the `parse_target` function from `build.rs` to support additional extensions, this is required until this crate is [updated to rust 1.75](https://github.com/rust-lang/rust/pull/116485) at which point we can use `target_feature`.

I added a little macro to help with zeroing registers, if it is preferable though happy to inline the zeroing of registers

I am new to rust & risc-v in general so apologies if there is any obvious mistakes that have been made, your feedback is greatly appreciated.

closes: #157