### PR TITLE
`riscv-rt`: add links to Cargo.toml

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `links` field in `Cargo.toml`
 - Add FPU initialization
 - Static array for vectored-like handling of exceptions
 - New GitHub workflow for checking invalid labels in PRs

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/riscv-rt"
 keywords = ["riscv", "runtime", "startup"]
 license = "ISC"
 edition = "2021"
+links = "riscv-rt" # Prevent multiple versions of riscv-rt being linked
 
 [features]
 s-mode = []

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -423,6 +423,10 @@ use riscv::register::mstatus as xstatus;
 
 pub use riscv_rt_macros::{entry, pre_init};
 
+/// We export this static with an informative name so that if an application attempts to link
+/// two copies of riscv-rt together, linking will fail. We also declare a links key in
+/// Cargo.toml which is the more modern way to solve the same problem, but we have to keep
+/// __ONCE__ around to prevent linking with versions before the links key was added.
 #[export_name = "error: riscv-rt appears more than once in the dependency graph"]
 #[doc(hidden)]
 pub static __ONCE__: () = ();


### PR DESCRIPTION
This PR solves #152

It uses the [`links`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-links-field) field in the `Cargo.toml` to avoid linking multiple versions of `riscv-rt`.