### PR TITLE
`riscv`: ECALL and nested interrupts

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `asm::ecall()`, a wrapper for implementing an `ecall` instruction
+- Add `nested` function for nested ISRs in `interrupt::machine` and `interrupt::supervisor`
 - `s-mode` feature for reexporting `interrupt::machine` or `interrupt::supervisor` to `interrupt`
 - Support for supervisor-level interrupts in `interrupt::supervisor`
 - Add CI workflow to check that CHANGELOG.md file has been modified in PRs

--- a/riscv/src/asm.rs
+++ b/riscv/src/asm.rs
@@ -110,6 +110,28 @@ pub unsafe fn sfence_vma(asid: usize, addr: usize) {
     }
 }
 
+/// `ECALL` instruction wrapper
+///
+/// Generates an exception for a service request to the execution environment.
+/// When executed in U-mode, S-mode, or M-mode, it generates an environment-call-from-U-mode
+/// exception, environment-call-from-S-mode exception, or environment-call-from-M-mode exception,
+/// respectively, and performs no other operation.
+///
+/// # Note
+///
+/// The ECALL instruction will **NOT** save and restore the stack pointer, as it triggers an exception.
+/// The stack pointer must be saved and restored accordingly by the exception handler.
+#[inline]
+pub unsafe fn ecall() {
+    match () {
+        #[cfg(riscv)]
+        () => core::arch::asm!("ecall", options(nostack)),
+
+        #[cfg(not(riscv))]
+        () => unimplemented!(),
+    }
+}
+
 /// Blocks the program for *at least* `cycles` CPU cycles.
 ///
 /// This is implemented in assembly so its execution time is independent of the optimization

--- a/riscv/src/interrupt.rs
+++ b/riscv/src/interrupt.rs
@@ -83,7 +83,7 @@ pub mod machine {
         }
 
         // Restore MSTATUS.PIE, MSTATUS.MPP, and SEPC
-        if !mstatus.mpie() {
+        if mstatus.mpie() {
             mstatus::set_mpie();
         }
         mstatus::set_mpp(mstatus.mpp());
@@ -172,7 +172,7 @@ pub mod supervisor {
         }
 
         // Restore SSTATUS.SPIE, SSTATUS.SPP, and SEPC
-        if !sstatus.spie() {
+        if sstatus.spie() {
             sstatus::set_spie();
         }
         sstatus::set_spp(sstatus.spp());

--- a/riscv/src/interrupt.rs
+++ b/riscv/src/interrupt.rs
@@ -3,11 +3,12 @@
 // NOTE: Adapted from cortex-m/src/interrupt.rs
 
 pub mod machine {
-    use crate::register::mstatus;
+    use crate::register::{mepc, mstatus};
 
     /// Disables all interrupts in the current hart (machine mode).
     #[inline]
     pub fn disable() {
+        // SAFETY: It is safe to disable interrupts
         unsafe { mstatus::clear_mie() }
     }
 
@@ -49,13 +50,55 @@ pub mod machine {
 
         r
     }
+
+    /// Execute closure `f` with interrupts enabled in the current hart (machine mode).
+    ///
+    /// This method is assumed to be called within an interrupt handler, and allows
+    /// nested interrupts to occur. After the closure `f` is executed, the [`mstatus`]
+    /// and [`mepc`] registers are properly restored to their previous values.
+    ///
+    /// # Safety
+    ///
+    /// - Do not call this function inside a critical section.
+    /// - This method is assumed to be called within an interrupt handler.
+    /// - Make sure to clear the interrupt flag that caused the interrupt before calling
+    /// this method. Otherwise, the interrupt will be re-triggered before executing `f`.
+    #[inline]
+    pub unsafe fn nested<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let mstatus = mstatus::read();
+        let mepc = mepc::read();
+
+        // enable interrupts to allow nested interrupts
+        enable();
+
+        let r = f();
+
+        // If the interrupts were inactive before our `enable` call, then re-disable
+        // them. Otherwise, keep them enabled
+        if !mstatus.mie() {
+            disable();
+        }
+
+        // Restore MSTATUS.PIE, MSTATUS.MPP, and SEPC
+        if !mstatus.mpie() {
+            mstatus::set_mpie();
+        }
+        mstatus::set_mpp(mstatus.mpp());
+        mepc::write(mepc);
+
+        r
+    }
 }
 pub mod supervisor {
-    use crate::register::sstatus;
+    use crate::register::{sepc, sstatus};
 
     /// Disables all interrupts in the current hart (supervisor mode).
     #[inline]
     pub fn disable() {
+        // SAFETY: It is safe to disable interrupts
         unsafe { sstatus::clear_sie() }
     }
 
@@ -94,6 +137,46 @@ pub mod supervisor {
         if sstatus.sie() {
             unsafe { enable() };
         }
+
+        r
+    }
+
+    /// Execute closure `f` with interrupts enabled in the current hart (supervisor mode).
+    /// This method is assumed to be called within an interrupt handler, and allows
+    /// nested interrupts to occur. After the closure `f` is executed, the [`sstatus`]
+    /// and [`sepc`] registers are properly restored to their previous values.
+    ///
+    /// # Safety
+    ///
+    /// - Do not call this function inside a critical section.
+    /// - This method is assumed to be called within an interrupt handler.
+    /// - Make sure to clear the interrupt flag that caused the interrupt before calling
+    /// this method. Otherwise, the interrupt will be re-triggered before executing `f`.
+    #[inline]
+    pub unsafe fn nested<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let sstatus = sstatus::read();
+        let sepc = sepc::read();
+
+        // enable interrupts to allow nested interrupts
+        enable();
+
+        let r = f();
+
+        // If the interrupts were inactive before our `enable` call, then re-disable
+        // them. Otherwise, keep them enabled
+        if !sstatus.sie() {
+            disable();
+        }
+
+        // Restore SSTATUS.SPIE, SSTATUS.SPP, and SEPC
+        if !sstatus.spie() {
+            sstatus::set_spie();
+        }
+        sstatus::set_spp(sstatus.spp());
+        sepc::write(sepc);
 
         r
     }


### PR DESCRIPTION
This PR adds a wrapper to trigger environment calls. It also adds a new function for allowing nested interrupts in M and S mode. Nested interrupts are specially useful for RTOSs, as they can implement preemption in this way.