### PR TITLE
`riscv-semihosting`: bug fixes

### DIFF
--- a/riscv-semihosting/CHANGELOG.md
+++ b/riscv-semihosting/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add recommendation for `semihosting` in README.md.
+- Bug fixes
 - Moved to the `riscv` Cargo workspace
 - Bring in API changes from
   [cortex-m-semihosting](https://github.com/rust-embedded/cortex-m/tree/master/cortex-m-semihosting),

--- a/riscv-semihosting/README.md
+++ b/riscv-semihosting/README.md
@@ -3,10 +3,10 @@
 
 # `riscv-semihosting`
 
-> Semihosting for RISC-V processors
+> Simple semihosting for RISC-V processors
 
 This is a fork of the
-[cortex-m-semihosting](https://docs.rs/cortex-m-semihosting) crate with changes
+[`cortex-m-semihosting`] crate with changes
 to support the RISC-V Semihosting Specification as documented
 [here](https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc)
 
@@ -22,6 +22,15 @@ calls are executed. The *machine-mode (M-mode)* feature will cause the macros in
 to execute the semihosting operation in an interrupt-free context, while
 *user-mode (U-mode)* causes them to just execute the operation.
 By default, M-mode is used. You can activate the U-mode via the `u-mode` feature.
+
+# About the [`semihosting`] crate
+
+`riscv-semihosting` provides a simple semihosting API that matches [`cortex-m-semihosting`].
+This allows a simple port from Cortex-M applications to RISC-V applications.
+However, the [`semihosting`] crate presents a more advanced interface that is compatible
+for RISC-V as well as other architectures (e.g., ARM or MIPS).
+While `riscv-semihosting` is a good starting point for developing semihosted applications,
+**we recommend using the [`semihosting`] crate.**
 
 
 # Minimum Supported Rust Version (MSRV)
@@ -59,3 +68,5 @@ to intervene to uphold that code of conduct.
 
 [CoC]: ../CODE_OF_CONDUCT.md
 [team]: https://github.com/rust-embedded/wg#the-risc-v-team
+[`semihosting`]: https://crates.io/crates/semihosting
+[`cortex-m-semihosting`]: https://docs.rs/cortex-m-semihosting

--- a/riscv-semihosting/src/lib.rs
+++ b/riscv-semihosting/src/lib.rs
@@ -231,7 +231,7 @@ pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
                 .option pop
             ",
             inout("a0") nr,
-            inout("a1") arg,
+            inout("a1") arg => _,
             options(nostack, preserves_flags),
             );
             nr

--- a/riscv-semihosting/src/lib.rs
+++ b/riscv-semihosting/src/lib.rs
@@ -216,11 +216,13 @@ pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
         #[cfg(all(riscv, not(feature = "no-semihosting")))]
         () => {
             let mut nr = _nr;
+            let mut arg = _arg;
             // The instructions below must always be uncompressed, otherwise
             // it will be treated as a regular break, hence the norvc option.
             //
             // See https://github.com/riscv/riscv-semihosting-spec for more details.
             asm!("
+                .balign 16
                 .option push
                 .option norvc
                 slli x0, x0, 0x1f
@@ -229,7 +231,8 @@ pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
                 .option pop
             ",
             inout("a0") nr,
-            in("a1") _arg,
+            inout("a1") arg,
+            options(nostack, preserves_flags),
             );
             nr
         }


### PR DESCRIPTION
This PR adds a reference to [`semihosting`](https://crates.io/crates/semihosting) in the `README.md` file, as this crate is preferred over `riscv-semihosting`.

I also addressed @taiki-e 's comments on #170 . (@taiki-e , could you take a look to confirm the issues are fixed?)