### PR TITLE
lib: update dependency embedded-hal to 1.0.0

### DIFF
--- a/riscv-semihosting/Cargo.toml
+++ b/riscv-semihosting/Cargo.toml
@@ -24,4 +24,4 @@ default = ["jlink-quirks"]
 
 [dependencies]
 critical-section = "1.0.0"
-riscv = {path = "../riscv", version = "0.10.1"}
+riscv = { path = "../riscv", version = "0.10.1" }

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Cargo workspace for riscv and riscv-rt
-- Update `embedded-hal` dependency to v1.0.0-rc.2 (bumps MSRV to 1.60)
+- Update `embedded-hal` dependency to v1.0.0 (bumps MSRV to 1.60)
 - `misa::MXL` renamed to `misa::XLEN`
 - Removed `bit_field` dependency
 - CI actions updated. They now use `checkout@v3` and `dtolnay/rust-toolchain`.

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -25,4 +25,4 @@ critical-section-single-hart = ["critical-section/restore-state-bool"]
 
 [dependencies]
 critical-section = "1.1.2"
-embedded-hal = "1.0.0-rc.2"
+embedded-hal = "1.0.0"

--- a/riscv/src/register/misa.rs
+++ b/riscv/src/register/misa.rs
@@ -46,8 +46,8 @@ impl Misa {
     ///
     /// # Example
     ///
-    /// ``` no_run
-    /// let misa = unsafe { riscv::register::misa::read() };
+    /// ```no_run
+    /// let misa = unsafe { riscv::register::misa::read() }.unwrap();
     /// assert!(misa.has_extension('A')); // panics if atomic extension is not implemented
     /// ```
     #[inline]


### PR DESCRIPTION
Update dependency embedded-hal to version 1.0.0.

There are also small fixes on document tests in file `misa.rs` and Cargo.toml code styles.
