### PR TITLE
`riscv-rt`: Support rv32e

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Moved all the assembly code to `asm.rs`
 - Use `weak` symbols for functions such as `_mp_hook` or `_start_trap`
+- Initial support for rv32e
 
 ### Removed
 

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -33,6 +33,8 @@ cfg_global_asm!(
     "// Provisional patch to avoid LLVM spurious errors when compiling in release mode.",
     #[cfg(all(riscv32, riscvm))]
     ".attribute arch, \"rv32im\"",
+    #[cfg(all(riscv32, riscve))]
+    ".attribute arch, \"rv32e\"",
     #[cfg(all(riscv64, riscvm, not(riscvg)))]
     ".attribute arch, \"rv64im\"",
     #[cfg(all(riscv64, riscvg))]

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -35,6 +35,12 @@ cfg_global_asm!(
     ".attribute arch, \"rv32im\"",
     #[cfg(all(riscv32, riscve))]
     ".attribute arch, \"rv32e\"",
+    #[cfg(all(riscv32, riscve, riscvc))]
+    ".attribute arch, \"rv32ec\"",
+    #[cfg(all(riscv32, riscve, riscvm))]
+    ".attribute arch, \"rv32em\"",
+    #[cfg(all(riscv32, riscve, riscvm, riscvc))]
+    ".attribute arch, \"rv32emc\"",
     #[cfg(all(riscv64, riscvm, not(riscvg)))]
     ".attribute arch, \"rv64im\"",
     #[cfg(all(riscv64, riscvg))]

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -172,9 +172,9 @@ cfg_global_asm!(
     bgeu t0, t2, 2f
 1:  ",
     #[cfg(target_arch = "riscv32")]
-    "lw t3, 0(t1)
+    "lw a5, 0(t1)
     addi t1, t1, 4
-    sw t3, 0(t0)
+    sw a5, 0(t0)
     addi t0, t0, 4
     bltu t0, t2, 1b",
     #[cfg(target_arch = "riscv64")]

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -446,9 +446,13 @@ pub struct TrapFrame {
     pub t0: usize,
     pub t1: usize,
     pub t2: usize,
+    #[cfg(not(riscve))]
     pub t3: usize,
+    #[cfg(not(riscve))]
     pub t4: usize,
+    #[cfg(not(riscve))]
     pub t5: usize,
+    #[cfg(not(riscve))]
     pub t6: usize,
     pub a0: usize,
     pub a1: usize,
@@ -456,7 +460,9 @@ pub struct TrapFrame {
     pub a3: usize,
     pub a4: usize,
     pub a5: usize,
+    #[cfg(not(riscve))]
     pub a6: usize,
+    #[cfg(not(riscve))]
     pub a7: usize,
 }
 


### PR DESCRIPTION
## BLUF

`riscv-rt` fails to link on `riscv32emc`. GCC complains about "mis-matched ISA string to merge 'i' and 'e'". This PR changes riscv-rt such that it _does_ link on `riscv32emc`, by removing accesses to registers that don't exist on RVE.

## Contents

As defined in RISC-V Unprivileged Spec. 20191213, the only change in RVE is to reduce the number of integer registers to 16 (x0-x15). This requires also a separate calling convention that seems a little underspecified.

Somebody on the internet said these are also implied by the respective `ilp32e` calling convention:

- 2 callee saved registers instead of 12 (but this is not relevant to us I think)
- 32-bit / 4-byte stack alignment instead of 128 bits / 16 bytes (this ***is*** relevant)

This PR does the following:

- Disable start of program load-to-zero for x16--x31 for RVE, since these do not exist on RVE
- Force & assert the stack pointer is 4-byte aligned on RVE instead of 16-byte align as on RVI
- Configure the trap handler to only caller-save a0--a5 (x10--x15) and t0--t2 (x5--x7) instead of a0--a7 (x10--x17) and t0--t6 (x5--x7 + x28--x31) on RVE
- Disable a6--a7 (x16--x17) and t3--t6 (x28--x31) for RVE in the `TrapFrame` struct, since these do not exist on RVE

## WIP

1. The latest `riscv-rt` master branch fails to compile when `codegen-units > 1` in Cargo.toml' `[profile.*]`.
    > .../riscv32-unknown-elf/bin/ld:link.x:77: undefined symbol `default_start_trap' referenced in expression

    But I think that is unrelated to the issue at hand. Perhaps worthy of its own issue.
2. I think this patch might not be ***all*** that is required for RVE support, but this is at least the minimal amount of changes that makes riscv-rt link on RVE, allowing further testing.
3. ~~FPGA testing pending. I won't be able to test the interrupts yet, but I should be able to confirm the runtime works otherwise.~~ Done.

## Extra context

We're building an RV32EMC in the lab. It's not supported by latest Rust, so we're rolling our own toolchain <https://github.com/soc-hub-fi/rust-rv32emc-docker> 😃 