### PR TITLE
`riscv-rt`: Fix nightly builds

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Implementation of `default_mp_hook` when `single-hart` feature is enabled.
+
 ## [v0.12.1] - 2024-01-24
 
 ### Added

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -744,10 +744,14 @@ pub static __INTERRUPTS: [Option<unsafe extern "C" fn()>; 12] = [
 pub extern "Rust" fn default_pre_init() {}
 
 /// Default implementation of `_mp_hook` wakes hart 0 and busy-loops all the other harts.
+/// Users can override this function by defining their own `_mp_hook`.
+/// 
+/// # Note
+/// 
+/// If the `single-hart` feature is enabled, `_mp_hook` is not called.
 #[doc(hidden)]
 #[no_mangle]
 #[rustfmt::skip]
-#[cfg(not(feature = "single-hart"))]
 pub extern "Rust" fn default_mp_hook(hartid: usize) -> bool {
     match hartid {
         0 => true,


### PR DESCRIPTION
Added an implementation of `default_mp_hook` even when `single-hart` feature is enabled. This is required to avoid linker errors in Nightly builds.