### PR TITLE
Release new `riscv-peripheral` crate and minor patches

### DIFF
--- a/riscv-pac/CHANGELOG.md
+++ b/riscv-pac/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.1] - 2024-02-15
+
 - Fix crates.io badge links
 
 ## [v0.1.0] - 2024-01-14

--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.0] - 2024-02-15
+
 ### Added
 
 - Add `ACLINT`, `CLINT`, and `PLIC` structs

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 embedded-hal = "1.0.0"
 embedded-hal-async = { version = "1.0.0", optional =  true }
-riscv = { path = "../riscv", version = "0.11.0" }
-riscv-pac = { path = "../riscv-pac", version = "0.1.0" }
+riscv = { path = "../riscv", version = "0.11.1" }
+riscv-pac = { path = "../riscv-pac", version = "0.1.1" }
 
 [dev-dependencies]
 heapless = "0.8.0"

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.12.2] - 2024-02-15
+
 ### Added
 
 - Implementation of `default_mp_hook` when `single-hart` feature is enabled.

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.12.1"
+version = "0.12.2"
 rust-version = "1.60"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
@@ -17,7 +17,7 @@ s-mode = []
 single-hart = []
 
 [dependencies]
-riscv = {path = "../riscv", version = "0.11.0"}
+riscv = {path = "../riscv", version = "0.11.1"}
 riscv-rt-macros = { path = "macros", version = "0.2.1" }
 
 [dev-dependencies]

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -756,7 +756,7 @@ pub extern "Rust" fn default_mp_hook(hartid: usize) -> bool {
     match hartid {
         0 => true,
         _ => loop {
-            unsafe { riscv::asm::wfi() }
+            riscv::asm::wfi();
         },
     }
 }

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.11.1] - 2024-02-15
+
 ### Changed
 
-- Made `asm::fence`, `fence_i` and `sfence` safe (ie, removed `unsafe` from their definitions)
+- Made `asm::wfi`, `fence`, `fence_i` and `sfence` safe (ie, removed `unsafe` from their definitions)
 
 ## [v0.11.0] - 2024-01-14
 

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.60"
 repository = "https://github.com/rust-embedded/riscv"

--- a/riscv/src/asm.rs
+++ b/riscv/src/asm.rs
@@ -48,7 +48,7 @@ instruction!(
     ///
     /// Provides a hint to the implementation that the current hart can be stalled until an interrupt might need servicing.
     /// The WFI instruction is just a hint, and a legal implementation is to implement WFI as a NOP.
-    , unsafe wfi, "wfi");
+    , wfi, "wfi");
 instruction!(
     /// `SFENCE.VMA` instruction wrapper (all address spaces and page table levels)
     ///


### PR DESCRIPTION
Minor releases with the changes of the latest PRs. I also made `asm::wfi` safe, following the criteria of `cortex-m`. Additionally, the `riscv-peripheral` crate is ready for its first release.

I will publish these new releases as soon as the PR gets merged.