### PR TITLE
`riscv-rt`: add `pre_init_trap` handler to detect errors during the boot process

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `pre_init_trap` to detect early errors during the boot process.
+
 ### Changed
 
 - Moved all the assembly code to `asm.rs`


### PR DESCRIPTION
I'm working on enabling the vectored interrupt mode in `riscv-rt`. To do so, I'm following [SiFive's RISC-V interrupt Cookbook](https://starfivetech.com/uploads/sifive-interrupt-cookbook-v1p2.pdf) and the [`esp-riscv-rt`](https://github.com/esp-rs/esp-hal/blob/main/esp-riscv-rt/src/lib.rs) crate.

Section 2.1.3 of the SiFive Cookbook provides information about requiring a pre-init trap handler to detect errors before the boot process. This issue is also outlined in #156.

This PR adds a simple `pre_init_trap` routine in the `.text.abort` section. At the beginning of `_abs_start`, interrupts are disabled and the `xtvec` register is configured to handle exceptions or interrupts at `pre_init_trap`. Once the boot process is done, `_setup_interrupts` redirects interrupts to `_start_trap`.

I thought about leaving `pre_init_trap` user-defined with a dummy default implementation. However, it is quite dangerous to leave users to add their code before the boot process is done. Thus, in my opinion, it is better to leave it like this, being the new trap just kind of a flag to allow us to detect bugs in `riscv-rt`.

**BEWARE:** I'm far from an assembly expert, so a double-check is welcome 😁. Also, the folks from `esp-rs` (ping @jessebraham @MabezDev) could provide very valuable feedback on this.

Closes #156
