### PR TITLE
Fix mistake in changelog

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `sip::set_ssoft` and `sip::clear_ssoft` using wrong address
+
 ## [v0.11.1] - 2024-02-15
 
 ### Changed
 
 - Made `asm::wfi`, `fence`, `fence_i` and `sfence` safe (ie, removed `unsafe` from their definitions)
-
-### Fixed
-
-- Fixed `sip::set_ssoft` and `sip::clear_ssoft` using wrong address
 
 ## [v0.11.0] - 2024-01-14
 


### PR DESCRIPTION
My last PR put the change in the wrong place - it should have gone under "unreleased"