### PR TITLE
`riscv-peripheral`: Support Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extensions

### DIFF
--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add support for CLIC <https://github.com/riscv/riscv-fast-interrupt/blob/master/clic.adoc>
+
 ## [v0.1.0] - 2024-02-15
 
 ### Added

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Interfaces for standard RISC-V peripherals"
 documentation = "https://docs.rs/riscv-peripheral"
-keywords = ["riscv", "peripheral", "clint", "plic"]
+keywords = ["riscv", "peripheral", "clint", "plic", "clic"]
 license = "ISC"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -24,6 +24,7 @@ heapless = "0.8.0"
 
 [features]
 aclint-hal-async = ["embedded-hal-async"]
+clic-smclic = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -25,6 +25,8 @@ heapless = "0.8.0"
 [features]
 aclint-hal-async = ["embedded-hal-async"]
 clic-smclic = []
+# CLIC selective hardware vectoring extension
+clic-smclicshv = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/riscv-peripheral/src/clic.rs
+++ b/riscv-peripheral/src/clic.rs
@@ -1,0 +1,112 @@
+//! Core-Local Interrupt Controller (CLIC) peripheral.
+//!
+//! Specification: <https://github.com/riscv/riscv-fast-interrupt/blob/master/clic.adoc>
+
+pub mod intattr;
+pub mod intctl;
+pub mod intie;
+pub mod intip;
+pub mod inttrig;
+#[cfg(feature = "clic-smclic")]
+pub mod smclicconfig;
+
+pub use riscv_pac::{HartIdNumber, InterruptNumber, PriorityNumber}; // re-export useful riscv-pac traits
+
+/// Trait for a CLIC peripheral.
+///
+/// # Safety
+///
+/// * This trait must only be implemented on a PAC of a target with a CLIC peripheral.
+/// * The CLIC peripheral base address `BASE` must be valid for the target device.
+pub unsafe trait Clic: Copy {
+    /// Base address of the CLIC peripheral.
+    const BASE: usize;
+}
+
+/// Core-Local Interrupt Controller (CLIC) peripheral.
+///
+/// The RISC-V standard does not specify a fixed location for the CLIC.
+/// Thus, each platform must specify the base address of the CLIC on the platform.
+/// The base address, as well as all the associated types, are defined in the [`Clic`] trait.
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CLIC<P: Clic> {
+    _marker: core::marker::PhantomData<P>,
+}
+
+impl<P: Clic> CLIC<P> {
+    #[cfg(feature = "clic-smclic")]
+    const SMCLICCONFIG_OFFSET: usize = 0x0;
+
+    const INTTRIG_OFFSET: usize = 0x40;
+    const INTTRIG_SEPARATION: usize = 0x4;
+
+    const INT_OFFSET: usize = 0x1000;
+    const INT_SEPARATION: usize = 0x4;
+
+    const INTIP_OFFSET: usize = 0x0;
+    const INTIE_OFFSET: usize = 0x1;
+    const INTATTR_OFFSET: usize = 0x2;
+    const INTCTL_OFFSET: usize = 0x3;
+
+    /// Returns the smclicconfig register of the CLIC.
+    #[inline]
+    #[cfg(feature = "clic-smclic")]
+    pub fn smclicconfig() -> smclicconfig::SMCLICCONFIG {
+        // SAFETY: valid address
+        unsafe { smclicconfig::SMCLICCONFIG::new(P::BASE + Self::SMCLICCONFIG_OFFSET) }
+    }
+
+    /// Returns the clicinttrig register for a given interrupt number.
+    #[inline]
+    pub fn inttrig<I: InterruptNumber>(int_nr: I) -> inttrig::INTTRIG {
+        let addr =
+            P::BASE + Self::INTTRIG_OFFSET + int_nr.number() as usize * Self::INTTRIG_SEPARATION;
+        // SAFETY: valid address
+        unsafe { inttrig::INTTRIG::new(addr) }
+    }
+
+    /// Returns the interrupts pending register of a given interrupt number.
+    #[inline]
+    pub fn ip<I: InterruptNumber>(int_nr: I) -> intip::INTIP {
+        let addr = P::BASE
+            + Self::INT_OFFSET
+            + int_nr.number() as usize * Self::INT_SEPARATION
+            + Self::INTIP_OFFSET;
+        // SAFETY: valid address
+        unsafe { intip::INTIP::new(addr) }
+    }
+
+    /// Returns the interrupts enable register of a given interrupt number.
+    #[inline]
+    pub fn ie<I: InterruptNumber>(int_nr: I) -> intie::INTIE {
+        let addr = P::BASE
+            + Self::INT_OFFSET
+            + int_nr.number() as usize * Self::INT_SEPARATION
+            + Self::INTIE_OFFSET;
+        // SAFETY: valid address
+        unsafe { intie::INTIE::new(addr) }
+    }
+
+    /// Returns the attribute register of a given interrupt number.
+    #[inline]
+    pub fn attr<I: InterruptNumber>(int_nr: I) -> intattr::INTATTR {
+        let addr = P::BASE
+            + Self::INT_OFFSET
+            + int_nr.number() as usize * Self::INT_SEPARATION
+            + Self::INTATTR_OFFSET;
+        // SAFETY: valid address
+        unsafe { intattr::INTATTR::new(addr) }
+    }
+
+    /// Returns the control register of this interrupt.
+    #[inline]
+    pub fn ctl<I: InterruptNumber>(int_nr: I) -> intctl::INTCTL {
+        let addr = P::BASE
+            + Self::INT_OFFSET
+            + int_nr.number() as usize * Self::INT_SEPARATION
+            + Self::INTCTL_OFFSET;
+        // SAFETY: valid address
+        unsafe { intctl::INTCTL::new(addr) }
+    }
+}

--- a/riscv-peripheral/src/clic.rs
+++ b/riscv-peripheral/src/clic.rs
@@ -44,11 +44,6 @@ impl<P: Clic> CLIC<P> {
     const INT_OFFSET: usize = 0x1000;
     const INT_SEPARATION: usize = 0x4;
 
-    const INTIP_OFFSET: usize = 0x0;
-    const INTIE_OFFSET: usize = 0x1;
-    const INTATTR_OFFSET: usize = 0x2;
-    const INTCTL_OFFSET: usize = 0x3;
-
     /// Returns the smclicconfig register of the CLIC.
     #[inline]
     #[cfg(feature = "clic-smclic")]
@@ -69,10 +64,7 @@ impl<P: Clic> CLIC<P> {
     /// Returns the interrupts pending register of a given interrupt number.
     #[inline]
     pub fn ip<I: InterruptNumber>(int_nr: I) -> intip::INTIP {
-        let addr = P::BASE
-            + Self::INT_OFFSET
-            + int_nr.number() as usize * Self::INT_SEPARATION
-            + Self::INTIP_OFFSET;
+        let addr = P::BASE + Self::INT_OFFSET + int_nr.number() as usize * Self::INT_SEPARATION;
         // SAFETY: valid address
         unsafe { intip::INTIP::new(addr) }
     }
@@ -80,21 +72,15 @@ impl<P: Clic> CLIC<P> {
     /// Returns the interrupts enable register of a given interrupt number.
     #[inline]
     pub fn ie<I: InterruptNumber>(int_nr: I) -> intie::INTIE {
-        let addr = P::BASE
-            + Self::INT_OFFSET
-            + int_nr.number() as usize * Self::INT_SEPARATION
-            + Self::INTIE_OFFSET;
-        // SAFETY: valid address
+        let addr = P::BASE + Self::INT_OFFSET + int_nr.number() as usize * Self::INT_SEPARATION;
+        // SAFETY: valid interrupt_number
         unsafe { intie::INTIE::new(addr) }
     }
 
     /// Returns the attribute register of a given interrupt number.
     #[inline]
     pub fn attr<I: InterruptNumber>(int_nr: I) -> intattr::INTATTR {
-        let addr = P::BASE
-            + Self::INT_OFFSET
-            + int_nr.number() as usize * Self::INT_SEPARATION
-            + Self::INTATTR_OFFSET;
+        let addr = P::BASE + Self::INT_OFFSET + int_nr.number() as usize * Self::INT_SEPARATION;
         // SAFETY: valid address
         unsafe { intattr::INTATTR::new(addr) }
     }
@@ -102,10 +88,7 @@ impl<P: Clic> CLIC<P> {
     /// Returns the control register of this interrupt.
     #[inline]
     pub fn ctl<I: InterruptNumber>(int_nr: I) -> intctl::INTCTL {
-        let addr = P::BASE
-            + Self::INT_OFFSET
-            + int_nr.number() as usize * Self::INT_SEPARATION
-            + Self::INTCTL_OFFSET;
+        let addr = P::BASE + Self::INT_OFFSET + int_nr.number() as usize * Self::INT_SEPARATION;
         // SAFETY: valid address
         unsafe { intctl::INTCTL::new(addr) }
     }

--- a/riscv-peripheral/src/clic/intattr.rs
+++ b/riscv-peripheral/src/clic/intattr.rs
@@ -112,4 +112,24 @@ impl INTATTR {
 
         reg.write_bits(2, 2, polarity as u8)
     }
+
+    /// Check the selective hardware vectoring mode for this interrupt.
+    #[inline]
+    #[cfg(feature = "clic-smclicshv")]
+    pub fn shv(self) -> bool {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.read_bit(0)
+    }
+
+    /// Set selective hardware vectoring mode for this interrupt.
+    #[inline]
+    #[cfg(feature = "clic-smclicshv")]
+    pub fn set_shv(self, shv: bool) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.write_bits(0, 0, shv as u8)
+    }
 }

--- a/riscv-peripheral/src/clic/intattr.rs
+++ b/riscv-peripheral/src/clic/intattr.rs
@@ -1,0 +1,115 @@
+//! CLIC interrupt attribute register.
+
+use crate::common::{Reg, RW};
+
+/// Privilege Mode
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum Mode {
+    Machine = 0b11,
+    Supervisor = 0b01,
+    User = 0b00,
+}
+
+/// Trigger type
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum Trig {
+    Level = 0b0,
+    Edge = 0b1,
+}
+
+/// Polarity
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum Polarity {
+    Pos = 0b0,
+    Neg = 0b1,
+}
+
+/// CLIC interrupt attribute register.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct INTATTR {
+    ptr: *mut u8,
+}
+
+impl INTATTR {
+    /// Creates a new interrupt attribute register from a base address.
+    ///
+    /// # Safety
+    ///
+    /// The base address must point to a valid interrupt attribute register.
+    #[inline]
+    pub(crate) const unsafe fn new(address: usize) -> Self {
+        Self { ptr: address as _ }
+    }
+
+    /// Check which privilege mode this interrupt operates in.
+    #[inline]
+    pub fn mode(self) -> Mode {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        match reg.read_bits(6, 7) {
+            0b00 => Mode::User,
+            0b01 => Mode::Supervisor,
+            0b11 => Mode::Machine,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Set the privilege mode this interrupt operates in.
+    #[inline]
+    pub fn set_mode(self, mode: Mode) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.write_bits(6, 7, mode as u8)
+    }
+
+    /// Check the trigger type for this interrupt.
+    #[inline]
+    pub fn trig(self) -> Trig {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        match reg.read_bit(1) {
+            false => Trig::Level,
+            true => Trig::Edge,
+        }
+    }
+
+    /// Set the trigger type for this interrupt.
+    #[inline]
+    pub fn set_trig(self, trig: Trig) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.write_bits(1, 1, trig as u8)
+    }
+
+    /// Check the polarity for this interrupt.
+    #[inline]
+    pub fn polarity(self) -> Polarity {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        match reg.read_bit(2) {
+            false => Polarity::Pos,
+            true => Polarity::Neg,
+        }
+    }
+
+    /// Set the polarity for this interrupt.
+    #[inline]
+    pub fn set_polarity(self, polarity: Polarity) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.write_bits(2, 2, polarity as u8)
+    }
+}

--- a/riscv-peripheral/src/clic/intctl.rs
+++ b/riscv-peripheral/src/clic/intctl.rs
@@ -1,6 +1,18 @@
 //! CLIC interrupt control register.
 
+use crate::common::{Reg, RW};
+
 /// CLIC interrupt control register.
+///
+/// A configurable number of upper bits in clicintctl[i] are assigned to encode the interrupt
+/// level.
+///
+/// The least-significant bits in clicintctl[i] that are not configured to be part of the
+/// interrupt level are interrupt priority, which are used to prioritize among interrupts
+/// pending-and-enabled at the same privilege mode and interrupt level. The highest-priority
+/// interrupt at a given privilege mode and interrupt level is taken first. In case there are
+/// multiple pending-and-enabled interrupts at the same highest priority, the highest-numbered
+/// interrupt is taken first.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct INTCTL {
@@ -8,6 +20,8 @@ pub struct INTCTL {
 }
 
 impl INTCTL {
+    const INTCTL_OFFSET: usize = 0x3;
+
     /// Creates a new interrupt control register from a base address.
     ///
     /// # Safety
@@ -16,5 +30,57 @@ impl INTCTL {
     #[inline]
     pub(crate) const unsafe fn new(address: usize) -> Self {
         Self { ptr: address as _ }
+    }
+
+    /// Check interrupt level for this interrupt.
+    #[inline]
+    pub fn level(self) -> u8 {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        // TODO: need to figure out how many are actually priority bits and how many are level bits
+        // and mask accordingly
+        reg.read_bits(8 * Self::INTCTL_OFFSET, 7 + 8 * Self::INTCTL_OFFSET) as u8
+    }
+
+    /// Set interrupt level for this interrupt.
+    #[inline]
+    pub fn set_level(self, level: u8) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        // TODO: need to figure out how many are actually priority bits and how many are level bits
+        // and mask accordingly
+        reg.write_bits(
+            8 * Self::INTCTL_OFFSET,
+            7 + 8 * Self::INTCTL_OFFSET,
+            level as _,
+        )
+    }
+
+    /// Check interrupt priority for this interrupt.
+    ///
+    /// N.b., 2024-03-11 rt-ss/CLIC does not implement priority bits at all at this time
+    #[inline]
+    pub fn priority(self) -> u32 {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        // TODO: need to figure out how many are actually priority bits and how many are level bits
+        // and mask accordingly
+        reg.read()
+    }
+
+    /// Set interrupt priority for this interrupt.
+    ///
+    /// N.b., 2024-03-11 rt-ss/CLIC does not implement priority bits at all at this time
+    #[inline]
+    pub fn set_priority(self, priority: u32) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        // TODO: need to figure out how many are actually priority bits and how many are level bits
+        // and mask accordingly
+        reg.write(priority)
     }
 }

--- a/riscv-peripheral/src/clic/intctl.rs
+++ b/riscv-peripheral/src/clic/intctl.rs
@@ -62,25 +62,29 @@ impl INTCTL {
     ///
     /// N.b., 2024-03-11 rt-ss/CLIC does not implement priority bits at all at this time
     #[inline]
-    pub fn priority(self) -> u32 {
+    pub fn priority(self) -> u8 {
         // SAFETY: valid interrupt number
         let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
 
         // TODO: need to figure out how many are actually priority bits and how many are level bits
         // and mask accordingly
-        reg.read()
+        reg.read_bits(8 * Self::INTCTL_OFFSET, 7 + 8 * Self::INTCTL_OFFSET) as u8
     }
 
     /// Set interrupt priority for this interrupt.
     ///
     /// N.b., 2024-03-11 rt-ss/CLIC does not implement priority bits at all at this time
     #[inline]
-    pub fn set_priority(self, priority: u32) {
+    pub fn set_priority(self, priority: u8) {
         // SAFETY: valid interrupt number
         let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
 
         // TODO: need to figure out how many are actually priority bits and how many are level bits
         // and mask accordingly
-        reg.write(priority)
+        reg.write_bits(
+            8 * Self::INTCTL_OFFSET,
+            7 + 8 * Self::INTCTL_OFFSET,
+            priority as _,
+        )
     }
 }

--- a/riscv-peripheral/src/clic/intctl.rs
+++ b/riscv-peripheral/src/clic/intctl.rs
@@ -4,7 +4,7 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct INTCTL {
-    ptr: *mut u8,
+    ptr: *mut u32,
 }
 
 impl INTCTL {

--- a/riscv-peripheral/src/clic/intctl.rs
+++ b/riscv-peripheral/src/clic/intctl.rs
@@ -1,0 +1,20 @@
+//! CLIC interrupt control register.
+
+/// CLIC interrupt control register.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct INTCTL {
+    ptr: *mut u8,
+}
+
+impl INTCTL {
+    /// Creates a new interrupt control register from a base address.
+    ///
+    /// # Safety
+    ///
+    /// The base address must point to a valid interrupt control register.
+    #[inline]
+    pub(crate) const unsafe fn new(address: usize) -> Self {
+        Self { ptr: address as _ }
+    }
+}

--- a/riscv-peripheral/src/clic/intie.rs
+++ b/riscv-peripheral/src/clic/intie.rs
@@ -1,0 +1,70 @@
+//! CLIC interrupt enable register.
+
+use crate::common::{Reg, RW};
+
+/// CLIC interrupt enable register.
+///
+/// Each interrupt input has a dedicated interrupt-enable bit (clicintie[i]) and occupies one byte
+/// in the memory map for ease of access. This control bit is read-write to enable/disable the
+/// corresponding interrupt. The enable bit is located in bit 0 of the byte. Software should assume
+/// clicintie[i]=0 means no interrupt enabled, and clicintie[i]!=0 indicates an interrupt is enabled
+/// to accommodate possible future expansion of the clicintie field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct INTIE {
+    ptr: *mut u8,
+}
+
+impl INTIE {
+    /// Creates a new interrupt enable register from a base address.
+    ///
+    /// # Safety
+    ///
+    /// The base address must point to a valid interrupt enable register.
+    #[inline]
+    pub(crate) const unsafe fn new(address: usize) -> Self {
+        Self { ptr: address as _ }
+    }
+
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn address(self) -> usize {
+        self.ptr as _
+    }
+
+    /// Checks if an interrupt source is enabled.
+    #[inline]
+    pub fn is_enabled(self) -> bool {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        // > Software should assume clicintie[i]=0 means no interrupt enabled, and clicintie[i]!=0
+        // > indicates an interrupt is enabled to accommodate possible future expansion of the
+        // > clicintie field.
+        reg.read() != 0
+    }
+
+    /// Enables an interrupt source.
+    ///
+    /// # Safety
+    ///
+    /// * Enabling an interrupt source can break mask-based critical sections.
+    #[inline]
+    pub unsafe fn enable(self) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        // >  The enable bit is located in bit 0 of the byte.
+        reg.set_bit(0);
+    }
+
+    /// Disables an interrupt source.
+    #[inline]
+    pub fn disable(self) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        // >  The enable bit is located in bit 0 of the byte.
+        reg.clear_bit(0);
+    }
+}

--- a/riscv-peripheral/src/clic/intip.rs
+++ b/riscv-peripheral/src/clic/intip.rs
@@ -1,0 +1,77 @@
+//! CLIC interrupt pending register.
+
+use crate::common::{Reg, RW};
+
+/// CLIC interrupt pending register.
+///
+/// > When the input is configured for edge-sensitive input, clicintip[i] is a read-write register
+/// > that can be updated both by hardware interrupt inputs and by software. The bit is set by
+/// > hardware after an edge of the appropriate polarity is observed on the interrupt input, as
+/// > determined by the clicintattr[i] field. Software writes to clicintip[i] can set or clear
+/// > edge-triggered pending bits directly by writes to the memory-mapped register. Edge-triggered
+/// > pending bits can also be cleared when a CSR instruction that accesses xnxti includes a write.
+/// > clicintip[i] behavior is unaffected by clicintie[i] setting.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct INTIP {
+    ptr: *mut u8,
+}
+
+impl INTIP {
+    /// Creates a new interrupt pending register from a base address.
+    ///
+    /// # Safety
+    ///
+    /// The base address must point to a valid interrupt pending register.
+    #[inline]
+    pub(crate) const unsafe fn new(address: usize) -> Self {
+        Self { ptr: address as _ }
+    }
+
+    /// Checks if an interrupt source is pending.
+    ///
+    /// # Safety
+    ///
+    /// * The value in the clicintip[i] is undefined when switching from level-sensitive mode to
+    ///   edge-triggered mode in clicintattr[i].
+    /// * Software cannot rely on the underlying clicintip[i] register bits used in edge-triggered
+    ///   mode to hold state while in level-sensitive mode.
+    #[inline]
+    pub unsafe fn is_pending(self) -> bool {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        // > Software should assume clicintip[i]=0 means no interrupt pending, and clicintip[i]!=0
+        // > indicates an interrupt is pending to accommodate possible future expansion of the
+        // > clicintip field.
+        reg.read() != 0
+    }
+
+    /// Pends an interrupt source.
+    ///
+    /// # Safety
+    ///
+    /// * Interrupt controller may or may not support software writes.
+    #[inline]
+    pub unsafe fn pend(self) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        // >  The enable bit is located in bit 0 of the byte.
+        reg.set_bit(0);
+    }
+
+    /// Unpends an interrupt source.
+    ///
+    /// # Safety
+    ///
+    /// * Interrupt controller may or may not support software writes.
+    #[inline]
+    pub unsafe fn unpend(self) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+
+        // >  The enable bit is located in bit 0 of the byte.
+        reg.clear_bit(0);
+    }
+}

--- a/riscv-peripheral/src/clic/intip.rs
+++ b/riscv-peripheral/src/clic/intip.rs
@@ -14,10 +14,12 @@ use crate::common::{Reg, RW};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct INTIP {
-    ptr: *mut u8,
+    ptr: *mut u32,
 }
 
 impl INTIP {
+    const INTIP_OFFSET: usize = 0x0;
+
     /// Creates a new interrupt pending register from a base address.
     ///
     /// # Safety
@@ -39,12 +41,12 @@ impl INTIP {
     #[inline]
     pub unsafe fn is_pending(self) -> bool {
         // SAFETY: valid interrupt number
-        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
 
         // > Software should assume clicintip[i]=0 means no interrupt pending, and clicintip[i]!=0
         // > indicates an interrupt is pending to accommodate possible future expansion of the
         // > clicintip field.
-        reg.read() != 0
+        reg.read_bit(0 + 8 * Self::INTIP_OFFSET)
     }
 
     /// Pends an interrupt source.
@@ -55,10 +57,10 @@ impl INTIP {
     #[inline]
     pub unsafe fn pend(self) {
         // SAFETY: valid interrupt number
-        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
 
         // >  The enable bit is located in bit 0 of the byte.
-        reg.set_bit(0);
+        reg.set_bit(0 + 8 * Self::INTIP_OFFSET);
     }
 
     /// Unpends an interrupt source.
@@ -69,9 +71,9 @@ impl INTIP {
     #[inline]
     pub unsafe fn unpend(self) {
         // SAFETY: valid interrupt number
-        let reg: Reg<u8, RW> = unsafe { Reg::new(self.ptr) };
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
 
         // >  The enable bit is located in bit 0 of the byte.
-        reg.clear_bit(0);
+        reg.clear_bit(0 + 8 * Self::INTIP_OFFSET);
     }
 }

--- a/riscv-peripheral/src/clic/inttrig.rs
+++ b/riscv-peripheral/src/clic/inttrig.rs
@@ -1,0 +1,24 @@
+//! CLIC interrupt trigger register.
+
+/// CLIC interrupt trigger register.
+///
+/// Optional interrupt triggers (clicinttrig[i]) are used to generate a breakpoint exception,
+/// entry into Debug Mode, or a trace action. If these registers are not implemented, they
+/// appear as hard-wired zeros.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct INTTRIG {
+    ptr: *mut u32,
+}
+
+impl INTTRIG {
+    /// Creates a new interrupt trigger register from a base address.
+    ///
+    /// # Safety
+    ///
+    /// The base address must point to a valid interrupt trigger register.
+    #[inline]
+    pub(crate) const unsafe fn new(address: usize) -> Self {
+        Self { ptr: address as _ }
+    }
+}

--- a/riscv-peripheral/src/clic/smclicconfig.rs
+++ b/riscv-peripheral/src/clic/smclicconfig.rs
@@ -1,0 +1,65 @@
+//! smclicconfig extension register.
+
+use crate::common::{Reg, RW};
+
+/// smclicconfig register.
+///
+/// Hardware implementations may wish to have a single implementation support different
+/// parameterizations of clic extensions. This extension defines that programmability.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct SMCLICCONFIG {
+    ptr: *mut u32,
+}
+
+impl SMCLICCONFIG {
+    /// Creates a smclicconfig register from a base address.
+    ///
+    /// # Safety
+    ///
+    /// The base address must point to a valid smclicconfig register.
+    #[inline]
+    pub(crate) const unsafe fn new(address: usize) -> Self {
+        Self { ptr: address as _ }
+    }
+
+    /// Check how many upper bits in `clicintctl[i]` are assigned to encode the interrupt level at
+    /// that privilege level.
+    #[inline]
+    pub fn mnlbits(self) -> u32 {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.read_bits(0, 3)
+    }
+
+    /// Set how many upper bits in `clicintctl[i]` are assigned to encode the interrupt level at
+    /// that privilege level.
+    #[inline]
+    pub fn set_mnlbits(self, mnlbits: u32) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.write_bits(0, 3, mnlbits)
+    }
+
+    /// Check how many bits are physically implemented in `clicintattr[i]`.mode to represent an input
+    /// i's privilege mode.
+    #[inline]
+    pub fn nmbits(self) -> u32 {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.read_bits(4, 5)
+    }
+
+    /// Check how many bits are physically implemented in `clicintattr[i]`.mode to represent an input
+    /// i's privilege mode.
+    #[inline]
+    pub fn set_nmbits(self, nmbits: u32) {
+        // SAFETY: valid interrupt number
+        let reg: Reg<u32, RW> = unsafe { Reg::new(self.ptr) };
+
+        reg.write_bits(4, 5, nmbits)
+    }
+}

--- a/riscv-peripheral/src/lib.rs
+++ b/riscv-peripheral/src/lib.rs
@@ -17,4 +17,5 @@ pub mod hal_async; // async trait implementations for embedded-hal
 pub mod macros; // macros for easing the definition of peripherals in PACs
 
 pub mod aclint; // ACLINT and CLINT peripherals
+pub mod clic; // CLIC peripheral
 pub mod plic; // PLIC peripheral

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Mcause::from(usize)` for use in unit tests
 - Add `Mstatus::from(usize)` for use in unit tests
 - Add `Mstatus.bits()`
+- Add `mtvec::TrapMode::Clic`
 
 ### Fixed
 

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -22,6 +22,7 @@ targets = [
 [features]
 s-mode = []
 critical-section-single-hart = ["critical-section/restore-state-bool"]
+clic = []
 
 [dependencies]
 critical-section = "1.1.2"

--- a/riscv/src/register/mtvec.rs
+++ b/riscv/src/register/mtvec.rs
@@ -11,6 +11,8 @@ pub struct Mtvec {
 pub enum TrapMode {
     Direct = 0,
     Vectored = 1,
+    #[cfg(feature = "clic")]
+    Clic = 0b11,
 }
 
 impl Mtvec {
@@ -33,6 +35,8 @@ impl Mtvec {
         match mode {
             0 => Some(TrapMode::Direct),
             1 => Some(TrapMode::Vectored),
+            #[cfg(feature = "clic")]
+            0b11 => Some(TrapMode::Clic),
             _ => None,
         }
     }


### PR DESCRIPTION
Specification: <https://github.com/riscv/riscv-fast-interrupt/blob/master/clic.adoc>

We've made a research prototype hardware implementation of rv32emc + CLIC and have completed preliminary tests showing that this software implementation for CLIC works. However, there's a few open issues:

- How to deal with dynamic RISC-V registers in software?
    - `riscv::register::mcause` dynamically allocates a different number of bits for `code` depending on whether `riscv::mtvec::trap_mode` is set to `Clic = 0b11` or not.
    - The number of bits allocated for priority and level in `riscv_peripheral::clic::intctl` depends on the value set in `riscv_peripheral::clic::smclicconfig::mnlbits`.
- We're investigating whether the fact that unaligned writes to CLIC registers fail is a problem with our HW design or a problem with RISC-V spec. This is making the current code cleanliness of the `clicintx` registers slightly un-ideal.
- CLIC is not yet ratified, as is the custom around here in the RISC-V world :)
- The CLIC spec if pretty big so we've only implemented the parts that are relevant to our use case with RTIC