### PR TITLE
`riscv-rt`: make `abort` weak

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Moved all the assembly code to `asm.rs`
 - Use `weak` symbols for functions such as `_mp_hook` or `_start_trap`
+- `abort` is now `weak`, so it is possible to link third-party libraries including this symbol.
 
 ### Removed
 

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -337,7 +337,7 @@ trap_handler!(
 #[rustfmt::skip]
 global_asm!(
     ".section .text.abort
-    .global abort
+.weak abort
 abort:  // make sure there is an abort symbol when linking
     j abort"
 );


### PR DESCRIPTION
Now, `abort` is a weak symbol. In this way, it is possible to link `riscv-rt` with third-party libraries that define this symbol (e.g., newlib).

Closes #197