### PR TITLE
`riscv-rt`: Support for vectored mode interrupt handling

### DIFF
--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ master, vectored-rt ]
+    branches: [ master ]
   pull_request:
   merge_group:
 

--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ master, riscv-rt-asm ]
+    branches: [ master, vectored-rt ]
   pull_request:
   merge_group:
 
@@ -39,6 +39,8 @@ jobs:
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=s-mode
       - name : Build (single-hart)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=single-hart
+      - name : Build (v-trap)
+        run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=v-trap
       - name: Build (all features)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --all-features
 

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add `pre_init_trap` to detect early errors during the boot process.
+- Add `v-trap` feature to enable interrupt handling in vectored mode.
+- Add `interrupt` proc macro to help defining interrupt handlers.
+If `v-trap` feature is enabled, this macro also generates its corresponding trap.
 
 ### Changed
 

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -19,6 +19,8 @@ If `v-trap` feature is enabled, this macro also generates its corresponding trap
 - Moved all the assembly code to `asm.rs`
 - Use `weak` symbols for functions such as `_mp_hook` or `_start_trap`
 - `abort` is now `weak`, so it is possible to link third-party libraries including this symbol.
+- `_start_trap_rust` now only deals with exceptions. When an interrupt is detected, it now calls
+to `_dispatch_interrupt`.
 
 ### Removed
 

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -12,13 +12,14 @@ license = "ISC"
 edition = "2021"
 links = "riscv-rt" # Prevent multiple versions of riscv-rt being linked
 
-[features]
-s-mode = []
-single-hart = []
-
 [dependencies]
 riscv = {path = "../riscv", version = "0.11.1"}
 riscv-rt-macros = { path = "macros", version = "0.2.1" }
 
 [dev-dependencies]
 panic-halt = "0.2.0"
+
+[features]
+s-mode = ["riscv-rt-macros/s-mode"]
+single-hart = []
+v-trap = ["riscv-rt-macros/v-trap"]

--- a/riscv-rt/examples/empty.rs
+++ b/riscv-rt/examples/empty.rs
@@ -4,10 +4,16 @@
 extern crate panic_halt;
 extern crate riscv_rt;
 
-use riscv_rt::entry;
+use riscv_rt::{entry, interrupt};
 
 #[entry]
 fn main() -> ! {
+    // do something here
+    loop {}
+}
+
+#[interrupt]
+fn MachineSoft() {
     // do something here
     loop {}
 }

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -28,6 +28,23 @@ PROVIDE(_max_hart_id = 0);
 PROVIDE(_hart_stack_size = 2K);
 PROVIDE(_heap_size = 0);
 
+/** TRAP ENTRY POINTS **/
+
+/* Default trap entry point. The riscv-rt crate provides a weak alias of this function,
+   which saves caller saved registers, calls _start_trap_rust, restores caller saved registers
+   and then returns. Users can override this alias by defining the symbol themselves */
+EXTERN(_start_trap);
+
+/* When vectored trap mode is enabled, each interrupt source must implement its own
+   trap entry point. By default, all interrupts start in _start_trap. However, users can
+   override these alias by defining the symbol themselves */
+PROVIDE(_start_SupervisorSoft_trap = _start_trap);
+PROVIDE(_start_MachineSoft_trap = _start_trap);
+PROVIDE(_start_SupervisorTimer_trap = _start_trap);
+PROVIDE(_start_MachineTimer_trap = _start_trap);
+PROVIDE(_start_SupervisorExternal_trap = _start_trap);
+PROVIDE(_start_MachineExternal_trap = _start_trap);
+
 /** EXCEPTION HANDLERS **/
 
 /* Default exception handler. The riscv-rt crate provides a weak alias of this function,

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -35,15 +35,20 @@ PROVIDE(_heap_size = 0);
    and then returns. Users can override this alias by defining the symbol themselves */
 EXTERN(_start_trap);
 
+/* Default interrupt trap entry point. When vectored trap mode is enabled,
+   the riscv-rt crate provides an implementation of this function, which saves caller saved
+   registers, calls the the DefaultHandler ISR, restores caller saved registers and returns. */
+PROVIDE(_start_DefaultHandler_trap = _start_trap);
+
 /* When vectored trap mode is enabled, each interrupt source must implement its own
    trap entry point. By default, all interrupts start in _start_trap. However, users can
    override these alias by defining the symbol themselves */
-PROVIDE(_start_SupervisorSoft_trap = _start_trap);
-PROVIDE(_start_MachineSoft_trap = _start_trap);
-PROVIDE(_start_SupervisorTimer_trap = _start_trap);
-PROVIDE(_start_MachineTimer_trap = _start_trap);
-PROVIDE(_start_SupervisorExternal_trap = _start_trap);
-PROVIDE(_start_MachineExternal_trap = _start_trap);
+PROVIDE(_start_SupervisorSoft_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_MachineSoft_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_SupervisorTimer_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_MachineTimer_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_SupervisorExternal_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_MachineExternal_trap = _start_DefaultHandler_trap);
 
 /** EXCEPTION HANDLERS **/
 
@@ -61,7 +66,7 @@ PROVIDE(Breakpoint = ExceptionHandler);
 PROVIDE(LoadMisaligned = ExceptionHandler);
 PROVIDE(LoadFault = ExceptionHandler);
 PROVIDE(StoreMisaligned = ExceptionHandler);
-PROVIDE(StoreFault = ExceptionHandler);;
+PROVIDE(StoreFault = ExceptionHandler);
 PROVIDE(UserEnvCall = ExceptionHandler);
 PROVIDE(SupervisorEnvCall = ExceptionHandler);
 PROVIDE(MachineEnvCall = ExceptionHandler);

--- a/riscv-rt/macros/Cargo.toml
+++ b/riscv-rt/macros/Cargo.toml
@@ -22,3 +22,7 @@ proc-macro2 = "1.0"
 [dependencies.syn]
 version = "1.0"
 features = ["extra-traits", "full"]
+
+[features]
+s-mode = []
+v-trap = []

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -312,3 +312,136 @@ pub fn loop_global_asm(input: TokenStream) -> TokenStream {
     let res = format!("core::arch::global_asm!(\n\"{}\"\n);", instructions);
     res.parse().unwrap()
 }
+
+enum RiscvArch {
+    Rv32,
+    Rv64,
+}
+
+#[proc_macro_attribute]
+pub fn interrupt_riscv32(args: TokenStream, input: TokenStream) -> TokenStream {
+    interrupt(args, input, RiscvArch::Rv32)
+}
+
+#[proc_macro_attribute]
+pub fn interrupt_riscv64(args: TokenStream, input: TokenStream) -> TokenStream {
+    interrupt(args, input, RiscvArch::Rv64)
+}
+
+fn interrupt(args: TokenStream, input: TokenStream, _arch: RiscvArch) -> TokenStream {
+    let f = parse_macro_input!(input as ItemFn);
+
+    // check the function signature
+    let valid_signature = f.sig.constness.is_none()
+        && f.sig.asyncness.is_none()
+        && f.vis == Visibility::Inherited
+        && f.sig.abi.is_none()
+        && f.sig.generics.params.is_empty()
+        && f.sig.generics.where_clause.is_none()
+        && f.sig.variadic.is_none()
+        && match f.sig.output {
+            ReturnType::Default => true,
+            ReturnType::Type(_, ref ty) => matches!(**ty, Type::Never(_)),
+        };
+
+    if !valid_signature {
+        return parse::Error::new(
+            f.span(),
+            "`#[interrupt]` function must have signature `[unsafe] fn() [-> !]`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    if !args.is_empty() {
+        return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
+            .to_compile_error()
+            .into();
+    }
+
+    // XXX should we blacklist other attributes?
+    let attrs = f.attrs;
+    let ident = f.sig.ident;
+    let block = f.block;
+
+    #[cfg(not(feature = "v-trap"))]
+    let start_trap = proc_macro2::TokenStream::new();
+    #[cfg(feature = "v-trap")]
+    let start_trap = v_trap::start_interrupt_trap_asm(&ident, _arch);
+
+    quote!(
+        #start_trap
+        #[export_name = #ident]
+        #(#attrs)*
+        pub unsafe fn #ident() #block
+    )
+    .into()
+}
+
+#[cfg(feature = "v-trap")]
+mod v_trap {
+    use super::*;
+
+    const TRAP_SIZE: usize = 16;
+
+    #[rustfmt::skip]
+    const TRAP_FRAME: [&str; TRAP_SIZE] = [
+        "ra",
+        "t0",
+        "t1",
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "a0",
+        "a1",
+        "a2",
+        "a3",
+        "a4",
+        "a5",
+        "a6",
+        "a7",
+    ];
+
+    pub fn start_interrupt_trap_asm(
+        ident: &syn::Ident,
+        arch: RiscvArch,
+    ) -> proc_macro2::TokenStream {
+        let function = ident.to_string();
+        let (width, store, load) = match arch {
+            RiscvArch::Rv32 => (4, "sw", "lw"),
+            RiscvArch::Rv64 => (8, "sd", "ld"),
+        };
+
+        let (mut stores, mut loads) = (Vec::new(), Vec::new());
+        for (i, r) in TRAP_FRAME.iter().enumerate() {
+            stores.push(format!("        {store} {r}, {i}*{width}(sp)"));
+            loads.push(format!("        {load} {r}, {i}*{width}(sp)"));
+        }
+        let store = stores.join("\n");
+        let load = loads.join("\n");
+
+        #[cfg(feature = "s-mode")]
+        let ret = "sret";
+        #[cfg(not(feature = "s-mode"))]
+        let ret = "mret";
+
+        let instructions = format!(
+            "
+core::arch::global_asm!(
+    \".section .trap, \\\"ax\\\"
+    .align {width}
+    _start_{function}_trap:
+        addi sp, sp, - {TRAP_SIZE} * {width}
+{store}
+        call {function}
+{load}
+        addi sp, sp, {TRAP_SIZE} * {width}
+        {ret}\"
+);"
+        );
+
+        instructions.parse().unwrap()
+    }
+}

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -426,9 +426,9 @@ fn weak_start_trap(arch: RiscvArch) -> TokenStream {
     let ret = "mret";
 
     format!(
-        "
+        r#"
 core::arch::global_asm!(
-\".section .trap, \\\"ax\\\"
+".section .trap, \\"ax\\"
 .align {width}
 .weak _start_trap
 _start_trap:
@@ -439,7 +439,7 @@ _start_trap:
     {load}
     addi sp, sp, {TRAP_SIZE} * {width}
     {ret}
-\");"
+");"#
     )
     .parse()
     .unwrap()
@@ -479,9 +479,9 @@ fn vectored_interrupt_trap(arch: RiscvArch) -> TokenStream {
     let ret = "mret";
 
     let instructions = format!(
-        "
+        r#"
 core::arch::global_asm!(
-\".section .trap, \\\"ax\\\"
+".section .trap, \\"ax\\"
 
 .global _start_DefaultHandler_trap
 _start_DefaultHandler_trap:
@@ -496,7 +496,7 @@ _continue_interrupt_trap:
     {load}                             // restore trap frame
     addi sp, sp, {TRAP_SIZE} * {width} // deallocate space for trap frame
     {ret}                              // return from interrupt
-\");"
+");"#
     );
 
     instructions.parse().unwrap()
@@ -584,9 +584,9 @@ fn start_interrupt_trap(ident: &syn::Ident, arch: RiscvArch) -> proc_macro2::Tok
     let store = store_trap(arch, |r| r == "a0");
 
     let instructions = format!(
-        "
+        r#"
 core::arch::global_asm!(
-    \".section .trap, \\\"ax\\\"
+    ".section .trap, \\"ax\\"
     .align 2
     .global _start_{interrupt}_trap
     _start_{interrupt}_trap:
@@ -594,7 +594,7 @@ core::arch::global_asm!(
         {store}                             // store trap partially (only register a0)
         la a0, {interrupt}                  // load interrupt handler address into a0
         j _continue_interrupt_trap          // jump to common part of interrupt trap
-\");"
+");"#
     );
 
     instructions.parse().unwrap()

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -282,6 +282,11 @@ riscv_rt_macros::weak_start_trap_riscv32!();
 #[cfg(riscv64)]
 riscv_rt_macros::weak_start_trap_riscv64!();
 
+#[cfg(all(riscv32, feature = "v-trap"))]
+riscv_rt_macros::vectored_interrupt_trap_riscv32!();
+#[cfg(all(riscv64, feature = "v-trap"))]
+riscv_rt_macros::vectored_interrupt_trap_riscv64!();
+
 #[cfg(feature = "v-trap")]
 cfg_global_asm!(
     // Set the vector mode to vectored.
@@ -297,15 +302,15 @@ cfg_global_asm!(
     _vector_table:
         j _start_trap                     // Interrupt 0 is used for exceptions
         j _start_SupervisorSoft_trap
-        j _start_trap                     // Interrupt 2 is reserved
+        j _start_DefaultHandler_trap      // Interrupt 2 is reserved
         j _start_MachineSoft_trap
-        j _start_trap                     // Interrupt 4 is reserved
+        j _start_DefaultHandler_trap      // Interrupt 4 is reserved
         j _start_SupervisorTimer_trap
-        j _start_trap                     // Interrupt 6 is reserved
+        j _start_DefaultHandler_trap      // Interrupt 6 is reserved
         j _start_MachineTimer_trap
-        j _start_trap                     // Interrupt 8 is reserved
+        j _start_DefaultHandler_trap      // Interrupt 8 is reserved
         j _start_SupervisorExternal_trap
-        j _start_trap                     // Interrupt 10 is reserved
+        j _start_DefaultHandler_trap      // Interrupt 10 is reserved
         j _start_MachineExternal_trap
 
         // default table does not include the remaining interrupts.

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -290,7 +290,7 @@ riscv_rt_macros::vectored_interrupt_trap_riscv64!();
 #[cfg(feature = "v-trap")]
 cfg_global_asm!(
     // Set the vector mode to vectored.
-    ".section .trap, \"ax\"
+    r#".section .trap, "ax"
     .weak _vector_table
     .type _vector_table, @function
     
@@ -316,7 +316,7 @@ cfg_global_asm!(
         // default table does not include the remaining interrupts.
         // Targets with extra interrupts should override this table.
     
-    .option pop",
+    .option pop"#,
 );
 
 #[rustfmt::skip]

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -429,6 +429,12 @@ use riscv::register::mcause as xcause;
 
 pub use riscv_rt_macros::{entry, pre_init};
 
+#[cfg(riscv32)]
+pub use riscv_rt_macros::interrupt_riscv32 as interrupt;
+
+#[cfg(riscv64)]
+pub use riscv_rt_macros::interrupt_riscv64 as interrupt;
+
 /// We export this static with an informative name so that if an application attempts to link
 /// two copies of riscv-rt together, linking will fail. We also declare a links key in
 /// Cargo.toml which is the more modern way to solve the same problem, but we have to keep

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -354,6 +354,18 @@
 //! }
 //! ```
 //!
+//! You can also use the `#[interrupt]` macro to define interrupt handlers:
+//!
+//! ``` no_run
+//! #[riscv_rt::interrupt]
+//! fn MachineTimer() {
+//!    // ...
+//! }
+//! ```
+//!
+//! In direct mode, this macro is equivalent to defining a function with the same name.
+//! However, in vectored mode, this macro will generate a proper trap handler for the interrupt.
+//!
 //! If interrupt handler is not explicitly defined, `DefaultHandler` is called.
 //!
 //! ### `DefaultHandler`
@@ -413,6 +425,33 @@
 //!   FLASH : ORIGIN = 0x20000000, LENGTH = 16M
 //! }
 //! ```
+//!
+//! ## `v-trap`
+//!
+//! The vectored trap feature (`v-trap`) can be activated via [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html).
+//!
+//! For example:
+//! ``` text
+//! [dependencies]
+//! riscv-rt = {features=["v-trap"]}
+//! ```
+//! When the vectored trap feature is enabled, the trap vector is set to `_vector_table` in vectored mode.
+//! This table is a list of `j _start_INTERRUPT_trap` instructions, where `INTERRUPT` is the name of the interrupt.
+//!
+//! ### Defining interrupt handlers in vectored mode
+//!
+//! In vectored mode, each interrupt must also have a corresponding trap handler.
+//! Therefore, using `export_name` or `no_mangle` is not enough to define an interrupt handler.
+//! The [`interrupt`] macro will generate the trap handler for the interrupt:
+//!
+//! ``` no_run
+//! #[riscv_rt::interrupt]
+//! fn MachineTimer() {
+//!    // ...
+//! }
+//! ```
+//!
+//! This will generate a function named `_start_MachineTimer_trap` that calls the interrupt handler `MachineTimer`.
 
 // NOTE: Adapted from cortex-m/src/lib.rs
 #![no_std]
@@ -481,7 +520,7 @@ pub struct TrapFrame {
 pub unsafe extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {
     extern "C" {
         fn ExceptionHandler(trap_frame: &TrapFrame);
-        fn DefaultHandler();
+        fn _dispatch_interrupt(code: usize);
     }
 
     let cause = xcause::read();
@@ -499,15 +538,8 @@ pub unsafe extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {
         } else {
             ExceptionHandler(trap_frame);
         }
-    } else if code < __INTERRUPTS.len() {
-        let h = &__INTERRUPTS[code];
-        if let Some(handler) = h {
-            handler();
-        } else {
-            DefaultHandler();
-        }
     } else {
-        DefaultHandler();
+        _dispatch_interrupt(code);
     }
 }
 
@@ -548,6 +580,24 @@ pub static __EXCEPTIONS: [Option<unsafe extern "C" fn(&TrapFrame)>; 16] = [
     None,
     Some(StorePageFault),
 ];
+
+#[export_name = "_dispatch_interrupt"]
+unsafe extern "C" fn dispatch_interrupt(code: usize) {
+    extern "C" {
+        fn DefaultHandler();
+    }
+
+    if code < __INTERRUPTS.len() {
+        let h = &__INTERRUPTS[code];
+        if let Some(handler) = h {
+            handler();
+        } else {
+            DefaultHandler();
+        }
+    } else {
+        DefaultHandler();
+    }
+}
 
 extern "C" {
     fn SupervisorSoft();


### PR DESCRIPTION
I am working on providing support for interrupt dispatching in vectored mode. This is a first draft, and I could not test yet if it works. However, I wanted to share it with you so I can start getting some feedback and suggestions about different design decisions. So, the main changes are:

- New `v-trap` feature to enable vectored mode. If this feature is enabled, the assembly code will add a trap vector with `j` instructions to a different trap per interrupt source. Some targets do not implement the standard interrupt convention (e.g., ESP32C3). That is why I left the table as weak. PACs will be able to replace this table accordingly.
- New `interrupt` procedural macro to implement interrupt handlers. Currently, in direct mode, this macro is quite dummy. However, I plan to add some parameters to the macro that will, eventually, allow us to "check" at compile time that the interrupt source name is an interrupt source of the target. Additionally, if `v-trap` feature is enabled, this macro will generate the trap handler to make sure that user registers are properly restored after executing the interrupt handler.

Also, I've been careful regarding how traps are generated to ease shortly the compatibility with the E extension (see #178).

This PR is still WIP, and I appreciate the feedback. Especially from the esp-rs folks (@MabezDev , @jessebraham) and @hegza , who already implemented a solution for this.

Closes #158 