### PR TITLE
riscv: build: make `cfg` variables more robust

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Moved all the assembly code to `asm.rs`
 - Use `weak` symbols for functions such as `_mp_hook` or `_start_trap`
 - `abort` is now `weak`, so it is possible to link third-party libraries including this symbol.
+- Made `cfg` variable selection more robust for custom targets
 
 ### Removed
 

--- a/riscv-rt/build.rs
+++ b/riscv-rt/build.rs
@@ -72,6 +72,16 @@ fn parse_target(target: &str, cargo_flags: &str) -> (u32, HashSet<char>) {
 }
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(riscv)");
+    println!("cargo:rustc-check-cfg=cfg(riscv32)");
+    println!("cargo:rustc-check-cfg=cfg(riscv64)");
+    println!("cargo:rustc-check-cfg=cfg(riscvi)");
+    println!("cargo:rustc-check-cfg=cfg(riscvm)");
+    println!("cargo:rustc-check-cfg=cfg(riscva)");
+    println!("cargo:rustc-check-cfg=cfg(riscvf)");
+    println!("cargo:rustc-check-cfg=cfg(riscvd)");
+    println!("cargo:rustc-check-cfg=cfg(riscvc)");
+
     let target = env::var("TARGET").unwrap();
     let cargo_flags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
     let _name = env::var("CARGO_PKG_NAME").unwrap();
@@ -79,7 +89,6 @@ fn main() {
     // set configuration flags depending on the target
     if target.starts_with("riscv") {
         println!("cargo:rustc-cfg=riscv");
-
         // This is required until target_arch & target_feature risc-v work is
         // stable and in-use (rust 1.75.0)
         let (bits, extensions) = parse_target(&target, &cargo_flags);

--- a/riscv-semihosting/CHANGELOG.md
+++ b/riscv-semihosting/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Made `cfg` variable selection more robust for custom targets
+
 ## [v0.1.0] - 2023-01-18
 
 - Add recommendation for `semihosting` in README.md.

--- a/riscv-semihosting/build.rs
+++ b/riscv-semihosting/build.rs
@@ -1,6 +1,8 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(riscv)");
+
     let target = env::var("TARGET").unwrap();
 
     if target.starts_with("riscv") {

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Made `asm::wfi`, `fence`, `fence_i` and `sfence` safe (ie, removed `unsafe` from their definitions)
+- Made `cfg` variable selection more robust for custom targets
 
 ## [v0.11.0] - 2024-01-14
 

--- a/riscv/build.rs
+++ b/riscv/build.rs
@@ -1,6 +1,10 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(riscv)");
+    println!("cargo:rustc-check-cfg=cfg(riscv32)");
+    println!("cargo:rustc-check-cfg=cfg(riscv64)");
+
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
     if target_arch == "riscv32" {

--- a/riscv/build.rs
+++ b/riscv/build.rs
@@ -1,12 +1,12 @@
 use std::env;
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
-    if target.starts_with("riscv32") {
+    if target_arch == "riscv32" {
         println!("cargo:rustc-cfg=riscv");
         println!("cargo:rustc-cfg=riscv32");
-    } else if target.starts_with("riscv64") {
+    } else if target_arch == "riscv64" {
         println!("cargo:rustc-cfg=riscv");
         println!("cargo:rustc-cfg=riscv64");
     }


### PR DESCRIPTION
Change which Cargo `CFG` environment variables are used to select the custom `cfg` variables.

See https://github.com/rust-embedded/riscv/pull/204#issuecomment-2094089195 for discussion.