### PR TITLE
Implement Eq and PartialEq for Range and Permission

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Mcause::from(usize)` for use in unit tests
 - Add `Mstatus::from(usize)` for use in unit tests
 - Add `Mstatus.bits()`
+- Add `Eq` and `PartialEq` for `pmpcfgx::{Range, Permission}`
 - Export `riscv::register::macros` module macros for external use
 
 ### Fixed

--- a/riscv/src/register/pmpcfgx.rs
+++ b/riscv/src/register/pmpcfgx.rs
@@ -1,7 +1,7 @@
 //! Physical memory protection configuration
 
 /// Permission enum contains all possible permission modes for pmp registers
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Permission {
     NONE = 0b000,
     R = 0b001,
@@ -14,7 +14,7 @@ pub enum Permission {
 }
 
 /// Range enum contains all possible addressing modes for pmp registers
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Range {
     OFF = 0b00,
     TOR = 0b01,


### PR DESCRIPTION
It's useful to be able to do equality tests for these for unit tests.

Should we do this more consistently?