### PR TITLE
Add Mstatus helpers to allow setting fields in Mstatus

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Mstatus::from(usize)` for use in unit tests
 - Add `Mstatus.bits()`
 - Add `Eq` and `PartialEq` for `pmpcfgx::{Range, Permission}`
-- Add `Mstatus::set_*` helpers to manipulate Mstatus values without touching the
-  CSR
+- Add `Mstatus::update_*` helpers to manipulate Mstatus values without touching
+  the CSR
 - Export `riscv::register::macros` module macros for external use
 
 ### Fixed

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Mstatus::from(usize)` for use in unit tests
 - Add `Mstatus.bits()`
 - Add `Eq` and `PartialEq` for `pmpcfgx::{Range, Permission}`
+- Add `Mstatus::set_*` helpers to manipulate Mstatus values without touching the
+  CSR
 - Export `riscv::register::macros` module macros for external use
 
 ### Fixed

--- a/riscv/src/bits.rs
+++ b/riscv/src/bits.rs
@@ -1,0 +1,17 @@
+/// Insert a new value into a bitfield
+///
+/// `value` is masked to `width` bits and inserted into `orig`.`
+#[inline]
+pub fn bf_insert(orig: usize, bit: usize, width: usize, value: usize) -> usize {
+    let mask = (1 << width) - 1;
+    orig & !(mask << bit) | ((value & mask) << bit)
+}
+
+/// Extract a value from a bitfield
+///
+/// Extracts `width` bits from bit offset `bit` and returns it shifted to bit 0.s
+#[inline]
+pub fn bf_extract(orig: usize, bit: usize, width: usize) -> usize {
+    let mask = (1 << width) - 1;
+    (orig >> bit) & mask
+}

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -36,6 +36,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 pub mod asm;
+pub(crate) mod bits;
 pub mod delay;
 pub mod interrupt;
 pub mod register;

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -160,6 +160,34 @@ macro_rules! write_csr_rv32 {
     };
 }
 
+/// Convenience macro to write a value with `bits` to a CSR
+#[macro_export]
+macro_rules! write_csr_as {
+    ($csr_type:ty, $csr_number:literal) => {
+        $crate::write_csr!($csr_number);
+
+        /// Writes the CSR
+        #[inline]
+        pub fn write(value: $csr_type) {
+            unsafe { _write(value.bits) }
+        }
+    };
+}
+
+/// Convenience macro to write a value to a CSR register.
+#[macro_export]
+macro_rules! write_csr_as_rv32 {
+    ($csr_type:ty, $csr_number:literal) => {
+        $crate::write_csr_rv32!($csr_number);
+
+        /// Writes the CSR
+        #[inline]
+        pub fn write(value: $csr_type) {
+            unsafe { _write(value.bits) }
+        }
+    };
+}
+
 /// Convenience macro to write a [`usize`] value to a CSR register.
 #[macro_export]
 macro_rules! write_csr_as_usize {

--- a/riscv/src/register/misa.rs
+++ b/riscv/src/register/misa.rs
@@ -11,9 +11,9 @@ pub struct Misa {
 /// Base integer ISA width
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum XLEN {
-    XLEN32,
-    XLEN64,
-    XLEN128,
+    XLEN32 = 1,
+    XLEN64 = 2,
+    XLEN128 = 3,
 }
 
 impl XLEN {

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -481,7 +481,7 @@ impl Mstatus {
 }
 
 read_csr_as!(Mstatus, 0x300);
-write_csr!(0x300);
+write_csr_as!(Mstatus, 0x300);
 set!(0x300);
 clear!(0x300);
 

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -593,3 +593,19 @@ pub unsafe fn set_mbe(endianness: Endianness) {
         },
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mpp() {
+        let mut mstatus = Mstatus { bits: 0 };
+        mstatus = mstatus.update_mpp(MPP::User);
+        assert_eq!(mstatus.mpp(), MPP::User);
+        mstatus = mstatus.update_mpp(MPP::Machine);
+        assert_eq!(mstatus.mpp(), MPP::Machine);
+        mstatus = mstatus.update_mpp(MPP::Supervisor);
+        assert_eq!(mstatus.mpp(), MPP::Supervisor);
+    }
+}

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -95,10 +95,11 @@ impl Mstatus {
 
     /// Update Supervisor Interrupt Enable
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_sie`]/[`clear_sie`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_sie`]/[`clear_sie`] to directly
+    /// update the CSR.
     #[inline]
-    pub fn update_sie(&self, sie: bool) -> Self {
+    pub fn set_sie(&self, sie: bool) -> Self {
         self.bf_insert(1, 1, sie as usize)
     }
 
@@ -110,10 +111,11 @@ impl Mstatus {
 
     /// Update Machine Interrupt Enable
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_mie`]/[`clear_mie`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_mie`]/[`clear_mie`] to directly
+    /// update the CSR.
     #[inline]
-    pub fn update_mie(&self, mie: bool) -> Self {
+    pub fn set_mie(&self, mie: bool) -> Self {
         self.bf_insert(3, 1, mie as usize)
     }
 
@@ -123,12 +125,13 @@ impl Mstatus {
         self.bits & (1 << 5) != 0
     }
 
-    /// Updateervisor Previous Interrupt Enable
+    /// Update Supervisor Previous Interrupt Enable
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_spie`]` to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_spie`]` to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_spie(&self, spie: bool) -> Self {
+    pub fn set_spie(&self, spie: bool) -> Self {
         self.bf_insert(5, 1, spie as usize)
     }
 
@@ -140,10 +143,11 @@ impl Mstatus {
 
     /// Update U-mode non-instruction-fetch memory endianness
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_ube`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_ube`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_ube(&self, endianness: Endianness) -> Self {
+    pub fn set_ube(&self, endianness: Endianness) -> Self {
         self.bf_insert(6, 1, endianness as usize)
     }
 
@@ -155,10 +159,11 @@ impl Mstatus {
 
     /// Update Machine Previous Interrupt Enable
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_mpie`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_mpie`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_mpie(&self, mpie: bool) -> Self {
+    pub fn set_mpie(&self, mpie: bool) -> Self {
         self.bf_insert(7, 1, mpie as usize)
     }
 
@@ -173,10 +178,11 @@ impl Mstatus {
 
     /// Update Supervisor Previous Privilege Mode
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_spp`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_spp`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_spp(&self, spp: SPP) -> Self {
+    pub fn set_spp(&self, spp: SPP) -> Self {
         self.bf_insert(8, 1, spp as usize)
     }
 
@@ -194,17 +200,18 @@ impl Mstatus {
 
     /// Update Machine Previous Privilege Mode
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_mpp`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_mpp`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_mpp(&self, mpp: MPP) -> Self {
+    pub fn set_mpp(&self, mpp: MPP) -> Self {
         self.bf_insert(11, 2, mpp as usize)
     }
 
     /// Floating-point extension state
     ///
-    /// Encodes the status of the floating-point unit,
-    /// including the CSR `fcsr` and floating-point data registers `f0–f31`.
+    /// Encodes the status of the floating-point unit, including the CSR `fcsr`
+    /// and floating-point data registers `f0–f31`.
     #[inline]
     pub fn fs(&self) -> FS {
         let fs = (self.bits >> 13) & 0x3; // bits 13-14
@@ -219,16 +226,18 @@ impl Mstatus {
 
     /// Update Floating-point extension state
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_fs`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_fs`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_fs(&self, fs: FS) -> Self {
+    pub fn set_fs(&self, fs: FS) -> Self {
         self.bf_insert(13, 2, fs as usize)
     }
 
     /// Additional extension state
     ///
-    /// Encodes the status of additional user-mode extensions and associated state.
+    /// Encodes the status of additional user-mode extensions and associated
+    /// state.
     #[inline]
     pub fn xs(&self) -> XS {
         let xs = (self.bits >> 15) & 0x3; // bits 15-16
@@ -243,10 +252,10 @@ impl Mstatus {
 
     /// Update Additional extension state
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself.
     #[inline]
-    pub fn update_xs(&self, xs: XS) -> Self {
+    pub fn set_xs(&self, xs: XS) -> Self {
         self.bf_insert(15, 2, xs as usize)
     }
 
@@ -258,10 +267,11 @@ impl Mstatus {
 
     /// Update Modify Memory PRiVilege
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_mprv`]/[`clear_mprv`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_mprv`]/[`clear_mprv`] to
+    /// directly update the CSR.
     #[inline]
-    pub fn update_mprv(&self, mprv: bool) -> Self {
+    pub fn set_mprv(&self, mprv: bool) -> Self {
         self.bf_insert(17, 1, mprv as usize)
     }
 
@@ -273,10 +283,11 @@ impl Mstatus {
 
     /// Update Permit Supervisor User Memory access
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_sum`]/[`clear_sum`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_sum`]/[`clear_sum`] to directly
+    /// update the CSR.
     #[inline]
-    pub fn update_sum(&self, sum: bool) -> Self {
+    pub fn set_sum(&self, sum: bool) -> Self {
         self.bf_insert(18, 1, sum as usize)
     }
 
@@ -288,10 +299,11 @@ impl Mstatus {
 
     /// Update Make eXecutable Readable
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_mxr`]/[`clear_mxr`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not affect
+    /// the mstatus CSR itself. See [`set_mxr`]/[`clear_mxr`] to directly update
+    /// the CSR.
     #[inline]
-    pub fn update_mxr(&self, mxr: bool) -> Self {
+    pub fn set_mxr(&self, mxr: bool) -> Self {
         self.bf_insert(19, 1, mxr as usize)
     }
 
@@ -308,10 +320,11 @@ impl Mstatus {
 
     /// Update Trap Virtual Memory
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_tvm`]/[`clear_tvm`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_tvm`]/[`clear_tvm`] to directly
+    /// update the CSR.
     #[inline]
-    pub fn update_tvm(&self, tvm: bool) -> Self {
+    pub fn set_tvm(&self, tvm: bool) -> Self {
         self.bf_insert(20, 1, tvm as usize)
     }
 
@@ -331,10 +344,11 @@ impl Mstatus {
 
     /// Update Timeout Wait
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_tw`]/[`clear_tw`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_tw`]/[`clear_tw`] to directly
+    /// update the CSR.
     #[inline]
-    pub fn update_tw(&self, tw: bool) -> Self {
+    pub fn set_tw(&self, tw: bool) -> Self {
         self.bf_insert(21, 1, tw as usize)
     }
 
@@ -351,10 +365,11 @@ impl Mstatus {
 
     /// Update Trap SRET
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_tsr`]/[`clear_tsr`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_tsr`]/[`clear_tsr`] to directly
+    /// update the CSR.
     #[inline]
-    pub fn update_tsr(&self, tsr: bool) -> Self {
+    pub fn set_tsr(&self, tsr: bool) -> Self {
         self.bf_insert(22, 1, tsr as usize)
     }
 
@@ -373,10 +388,10 @@ impl Mstatus {
 
     /// Update Effective xlen in U-mode (i.e., `UXLEN`).
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself.
     #[inline]
-    pub fn update_uxl(&self, uxl: XLEN) -> Self {
+    pub fn set_uxl(&self, uxl: XLEN) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -400,10 +415,10 @@ impl Mstatus {
 
     /// Update Effective xlen in S-mode (i.e., `SXLEN`).
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself.
     #[inline]
-    pub fn update_sxl(&self, sxl: XLEN) -> Self {
+    pub fn set_sxl(&self, sxl: XLEN) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -426,10 +441,11 @@ impl Mstatus {
 
     /// Update S-mode non-instruction-fetch memory endianness
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_sbe`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_sbe`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_sbe(&self, endianness: Endianness) -> Self {
+    pub fn set_sbe(&self, endianness: Endianness) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -451,10 +467,11 @@ impl Mstatus {
     }
     /// Update M-mode non-instruction-fetch memory endianness
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself. See [`set_mbe`] to directly update the CSR.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself. See [`set_mbe`] to directly update the
+    /// CSR.
     #[inline]
-    pub fn update_mbe(&self, endianness: Endianness) -> Self {
+    pub fn set_mbe(&self, endianness: Endianness) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -472,10 +489,10 @@ impl Mstatus {
     /// Update whether either the FS field or XS field signals the presence of
     /// some dirty state
     ///
-    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
-    /// CSR itself.
+    /// Note this updates a previously read [`Mstatus`] value, but does not
+    /// affect the mstatus CSR itself.
     #[inline]
-    pub fn update_sd(&self, sd: bool) -> Self {
+    pub fn set_sd(&self, sd: bool) -> Self {
         self.bf_insert(usize::BITS as usize - 1, 1, sd as usize)
     }
 }
@@ -601,11 +618,11 @@ mod test {
     #[test]
     fn test_mpp() {
         let mut mstatus = Mstatus { bits: 0 };
-        mstatus = mstatus.update_mpp(MPP::User);
+        mstatus = mstatus.set_mpp(MPP::User);
         assert_eq!(mstatus.mpp(), MPP::User);
-        mstatus = mstatus.update_mpp(MPP::Machine);
+        mstatus = mstatus.set_mpp(MPP::Machine);
         assert_eq!(mstatus.mpp(), MPP::Machine);
-        mstatus = mstatus.update_mpp(MPP::Supervisor);
+        mstatus = mstatus.set_mpp(MPP::Supervisor);
         assert_eq!(mstatus.mpp(), MPP::Supervisor);
     }
 }

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -93,9 +93,12 @@ impl Mstatus {
         self.bits & (1 << 1) != 0
     }
 
-    /// Set Supervisor Interrupt Enable
+    /// Update Supervisor Interrupt Enable
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_sie`]/[`clear_sie`] to directly update the CSR.
     #[inline]
-    pub fn set_sie(&self, sie: bool) -> Self {
+    pub fn update_sie(&self, sie: bool) -> Self {
         self.bf_insert(1, 1, sie as usize)
     }
 
@@ -105,9 +108,12 @@ impl Mstatus {
         self.bits & (1 << 3) != 0
     }
 
-    /// Set Machine Interrupt Enable
+    /// Update Machine Interrupt Enable
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_mie`]/[`clear_mie`] to directly update the CSR.
     #[inline]
-    pub fn set_mie(&self, mie: bool) -> Self {
+    pub fn update_mie(&self, mie: bool) -> Self {
         self.bf_insert(3, 1, mie as usize)
     }
 
@@ -117,9 +123,12 @@ impl Mstatus {
         self.bits & (1 << 5) != 0
     }
 
-    /// Supervisor Previous Interrupt Enable
+    /// Updateervisor Previous Interrupt Enable
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_spie`]` to directly update the CSR.
     #[inline]
-    pub fn set_spie(&self, spie: bool) -> Self {
+    pub fn update_spie(&self, spie: bool) -> Self {
         self.bf_insert(5, 1, spie as usize)
     }
 
@@ -129,9 +138,12 @@ impl Mstatus {
         Endianness::from(self.bits & (1 << 6) != 0)
     }
 
-    /// Set U-mode non-instruction-fetch memory endianness
+    /// Update U-mode non-instruction-fetch memory endianness
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_ube`] to directly update the CSR.
     #[inline]
-    pub fn set_ube(&self, endianness: Endianness) -> Self {
+    pub fn update_ube(&self, endianness: Endianness) -> Self {
         self.bf_insert(6, 1, endianness as usize)
     }
 
@@ -141,9 +153,12 @@ impl Mstatus {
         self.bits & (1 << 7) != 0
     }
 
-    /// Set Machine Previous Interrupt Enable
+    /// Update Machine Previous Interrupt Enable
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_mpie`] to directly update the CSR.
     #[inline]
-    pub fn set_mpie(&self, mpie: bool) -> Self {
+    pub fn update_mpie(&self, mpie: bool) -> Self {
         self.bf_insert(7, 1, mpie as usize)
     }
 
@@ -156,9 +171,12 @@ impl Mstatus {
         }
     }
 
-    /// Set Supervisor Previous Privilege Mode
+    /// Update Supervisor Previous Privilege Mode
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_spp`] to directly update the CSR.
     #[inline]
-    pub fn set_spp(&self, spp: SPP) -> Self {
+    pub fn update_spp(&self, spp: SPP) -> Self {
         self.bf_insert(8, 1, spp as usize)
     }
 
@@ -174,9 +192,12 @@ impl Mstatus {
         }
     }
 
-    /// Set Machine Previous Privilege Mode
+    /// Update Machine Previous Privilege Mode
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_mpp`] to directly update the CSR.
     #[inline]
-    pub fn set_mpp(&self, mpp: MPP) -> Self {
+    pub fn update_mpp(&self, mpp: MPP) -> Self {
         self.bf_insert(11, 2, mpp as usize)
     }
 
@@ -196,9 +217,12 @@ impl Mstatus {
         }
     }
 
-    /// Set Floating-point extension state
+    /// Update Floating-point extension state
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_fs`] to directly update the CSR.
     #[inline]
-    pub fn set_fs(&self, fs: FS) -> Self {
+    pub fn update_fs(&self, fs: FS) -> Self {
         self.bf_insert(13, 2, fs as usize)
     }
 
@@ -217,9 +241,12 @@ impl Mstatus {
         }
     }
 
-    /// Set Additional extension state
+    /// Update Additional extension state
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself.
     #[inline]
-    pub fn set_xs(&self, xs: XS) -> Self {
+    pub fn update_xs(&self, xs: XS) -> Self {
         self.bf_insert(15, 2, xs as usize)
     }
 
@@ -229,9 +256,12 @@ impl Mstatus {
         self.bits & (1 << 17) != 0
     }
 
-    /// Set Modify Memory PRiVilege
+    /// Update Modify Memory PRiVilege
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_mprv`]/[`clear_mprv`] to directly update the CSR.
     #[inline]
-    pub fn set_mprv(&self, mprv: bool) -> Self {
+    pub fn update_mprv(&self, mprv: bool) -> Self {
         self.bf_insert(17, 1, mprv as usize)
     }
 
@@ -241,9 +271,12 @@ impl Mstatus {
         self.bits & (1 << 18) != 0
     }
 
-    /// Set Permit Supervisor User Memory access
+    /// Update Permit Supervisor User Memory access
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_sum`]/[`clear_sum`] to directly update the CSR.
     #[inline]
-    pub fn set_sum(&self, sum: bool) -> Self {
+    pub fn update_sum(&self, sum: bool) -> Self {
         self.bf_insert(18, 1, sum as usize)
     }
 
@@ -253,9 +286,12 @@ impl Mstatus {
         self.bits & (1 << 19) != 0
     }
 
-    /// Set Make eXecutable Readable
+    /// Update Make eXecutable Readable
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_mxr`]/[`clear_mxr`] to directly update the CSR.
     #[inline]
-    pub fn set_mxr(&self, mxr: bool) -> Self {
+    pub fn update_mxr(&self, mxr: bool) -> Self {
         self.bf_insert(19, 1, mxr as usize)
     }
 
@@ -270,9 +306,12 @@ impl Mstatus {
         self.bits & (1 << 20) != 0
     }
 
-    /// Set Trap Virtual Memory
+    /// Update Trap Virtual Memory
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_tvm`]/[`clear_tvm`] to directly update the CSR.
     #[inline]
-    pub fn set_tvm(&self, tvm: bool) -> Self {
+    pub fn update_tvm(&self, tvm: bool) -> Self {
         self.bf_insert(20, 1, tvm as usize)
     }
 
@@ -290,9 +329,12 @@ impl Mstatus {
         self.bits & (1 << 21) != 0
     }
 
-    /// Set Timeout Wait
+    /// Update Timeout Wait
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_tw`]/[`clear_tw`] to directly update the CSR.
     #[inline]
-    pub fn set_tw(&self, tw: bool) -> Self {
+    pub fn update_tw(&self, tw: bool) -> Self {
         self.bf_insert(21, 1, tw as usize)
     }
 
@@ -307,9 +349,12 @@ impl Mstatus {
         self.bits & (1 << 22) != 0
     }
 
-    /// Set Trap SRET
+    /// Update Trap SRET
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_tsr`]/[`clear_tsr`] to directly update the CSR.
     #[inline]
-    pub fn set_tsr(&self, tsr: bool) -> Self {
+    pub fn update_tsr(&self, tsr: bool) -> Self {
         self.bf_insert(22, 1, tsr as usize)
     }
 
@@ -326,9 +371,12 @@ impl Mstatus {
         }
     }
 
-    /// Set Effective xlen in U-mode (i.e., `UXLEN`).
+    /// Update Effective xlen in U-mode (i.e., `UXLEN`).
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself.
     #[inline]
-    pub fn set_uxl(&self, uxl: XLEN) -> Self {
+    pub fn update_uxl(&self, uxl: XLEN) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -350,9 +398,12 @@ impl Mstatus {
         }
     }
 
-    /// Set Effective xlen in S-mode (i.e., `SXLEN`).
+    /// Update Effective xlen in S-mode (i.e., `SXLEN`).
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself.
     #[inline]
-    pub fn set_sxl(&self, sxl: XLEN) -> Self {
+    pub fn update_sxl(&self, sxl: XLEN) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -373,9 +424,12 @@ impl Mstatus {
         }
     }
 
-    /// Set S-mode non-instruction-fetch memory endianness
+    /// Update S-mode non-instruction-fetch memory endianness
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_sbe`] to directly update the CSR.
     #[inline]
-    pub fn set_sbe(&self, endianness: Endianness) -> Self {
+    pub fn update_sbe(&self, endianness: Endianness) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -395,9 +449,12 @@ impl Mstatus {
             () => Endianness::from(self.bits & (1 << 37) != 0),
         }
     }
-
-    /// Set M-mode non-instruction-fetch memory endianness
-    pub fn set_mbe(&self, endianness: Endianness) -> Self {
+    /// Update M-mode non-instruction-fetch memory endianness
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself. See [`set_mbe`] to directly update the CSR.
+    #[inline]
+    pub fn update_mbe(&self, endianness: Endianness) -> Self {
         #[cfg(riscv32)]
         {
             *self
@@ -412,9 +469,13 @@ impl Mstatus {
         self.bits & (1 << (usize::BITS as usize - 1)) != 0
     }
 
-    /// Set whether either the FS field or XS field signals the presence of some dirty state
+    /// Update whether either the FS field or XS field signals the presence of
+    /// some dirty state
+    ///
+    /// Note this updates the [`Mstatus`] value, but does not affect the mstatus
+    /// CSR itself.
     #[inline]
-    pub fn set_sd(&self, sd: bool) -> Self {
+    pub fn update_sd(&self, sd: bool) -> Self {
         self.bf_insert(usize::BITS as usize - 1, 1, sd as usize)
     }
 }

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -73,20 +73,6 @@ impl From<bool> for Endianness {
 }
 
 impl Mstatus {
-    /// Helper to insert a bitfield into Mstatus
-    #[inline]
-    fn bf_insert(&self, bit: usize, width: usize, val: usize) -> Self {
-        Self {
-            bits: bf_insert(self.bits, bit, width, val),
-        }
-    }
-
-    /// Helper to extract a bitfield from Mstatus
-    #[inline]
-    fn bf_extract(&self, bit: usize, width: usize) -> usize {
-        bf_extract(self.bits, bit, width)
-    }
-
     /// Returns the contents of the register as raw bits
     #[inline]
     pub fn bits(&self) -> usize {
@@ -96,7 +82,7 @@ impl Mstatus {
     /// Supervisor Interrupt Enable
     #[inline]
     pub fn sie(&self) -> bool {
-        self.bf_extract(1, 1) != 0
+        bf_extract(self.bits, 1, 1) != 0
     }
 
     /// Update Supervisor Interrupt Enable
@@ -105,14 +91,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_sie`]/[`clear_sie`] to directly
     /// update the CSR.
     #[inline]
-    pub fn set_sie(&self, sie: bool) -> Self {
-        self.bf_insert(1, 1, sie as usize)
+    pub fn set_sie(&mut self, sie: bool) {
+        self.bits = bf_insert(self.bits, 1, 1, sie as usize);
     }
 
     /// Machine Interrupt Enable
     #[inline]
     pub fn mie(&self) -> bool {
-        self.bf_extract(3, 1) != 0
+        bf_extract(self.bits, 3, 1) != 0
     }
 
     /// Update Machine Interrupt Enable
@@ -121,14 +107,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_mie`]/[`clear_mie`] to directly
     /// update the CSR.
     #[inline]
-    pub fn set_mie(&self, mie: bool) -> Self {
-        self.bf_insert(3, 1, mie as usize)
+    pub fn set_mie(&mut self, mie: bool) {
+        self.bits = bf_insert(self.bits, 3, 1, mie as usize);
     }
 
     /// Supervisor Previous Interrupt Enable
     #[inline]
     pub fn spie(&self) -> bool {
-        self.bf_extract(5, 1) != 0
+        bf_extract(self.bits, 5, 1) != 0
     }
 
     /// Update Supervisor Previous Interrupt Enable
@@ -137,14 +123,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_spie`]` to directly update the
     /// CSR.
     #[inline]
-    pub fn set_spie(&self, spie: bool) -> Self {
-        self.bf_insert(5, 1, spie as usize)
+    pub fn set_spie(&mut self, spie: bool) {
+        self.bits = bf_insert(self.bits, 5, 1, spie as usize);
     }
 
     /// U-mode non-instruction-fetch memory endianness
     #[inline]
     pub fn ube(&self) -> Endianness {
-        Endianness::from(self.bf_extract(6, 1) != 0)
+        Endianness::from(bf_extract(self.bits, 6, 1) != 0)
     }
 
     /// Update U-mode non-instruction-fetch memory endianness
@@ -153,14 +139,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_ube`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_ube(&self, endianness: Endianness) -> Self {
-        self.bf_insert(6, 1, endianness as usize)
+    pub fn set_ube(&mut self, endianness: Endianness) {
+        self.bits = bf_insert(self.bits, 6, 1, endianness as usize);
     }
 
     /// Machine Previous Interrupt Enable
     #[inline]
     pub fn mpie(&self) -> bool {
-        self.bf_extract(7, 1) != 0
+        bf_extract(self.bits, 7, 1) != 0
     }
 
     /// Update Machine Previous Interrupt Enable
@@ -169,14 +155,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_mpie`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_mpie(&self, mpie: bool) -> Self {
-        self.bf_insert(7, 1, mpie as usize)
+    pub fn set_mpie(&mut self, mpie: bool) {
+        self.bits = bf_insert(self.bits, 7, 1, mpie as usize);
     }
 
     /// Supervisor Previous Privilege Mode
     #[inline]
     pub fn spp(&self) -> SPP {
-        match self.bf_extract(7, 1) != 0 {
+        match bf_extract(self.bits, 8, 1) != 0 {
             true => SPP::Supervisor,
             false => SPP::User,
         }
@@ -188,14 +174,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_spp`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_spp(&self, spp: SPP) -> Self {
-        self.bf_insert(8, 1, spp as usize)
+    pub fn set_spp(&mut self, spp: SPP) {
+        self.bits = bf_insert(self.bits, 8, 1, spp as usize);
     }
 
     /// Machine Previous Privilege Mode
     #[inline]
     pub fn mpp(&self) -> MPP {
-        let mpp = self.bf_extract(11, 2); // bits 11-12
+        let mpp = bf_extract(self.bits, 11, 2); // bits 11-12
         match mpp {
             0b00 => MPP::User,
             0b01 => MPP::Supervisor,
@@ -210,8 +196,8 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_mpp`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_mpp(&self, mpp: MPP) -> Self {
-        self.bf_insert(11, 2, mpp as usize)
+    pub fn set_mpp(&mut self, mpp: MPP) {
+        self.bits = bf_insert(self.bits, 11, 2, mpp as usize);
     }
 
     /// Floating-point extension state
@@ -220,7 +206,7 @@ impl Mstatus {
     /// and floating-point data registers `f0–f31`.
     #[inline]
     pub fn fs(&self) -> FS {
-        let fs = self.bf_extract(13, 2); // bits 13-14
+        let fs = bf_extract(self.bits, 13, 2); // bits 13-14
         match fs {
             0b00 => FS::Off,
             0b01 => FS::Initial,
@@ -236,8 +222,8 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_fs`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_fs(&self, fs: FS) -> Self {
-        self.bf_insert(13, 2, fs as usize)
+    pub fn set_fs(&mut self, fs: FS) {
+        self.bits = bf_insert(self.bits, 13, 2, fs as usize);
     }
 
     /// Additional extension state
@@ -246,7 +232,7 @@ impl Mstatus {
     /// state.
     #[inline]
     pub fn xs(&self) -> XS {
-        let xs = self.bf_extract(15, 2); // bits 15-16
+        let xs = bf_extract(self.bits, 15, 2); // bits 15-16
         match xs {
             0b00 => XS::AllOff,
             0b01 => XS::NoneDirtyOrClean,
@@ -261,14 +247,14 @@ impl Mstatus {
     /// Note this updates a previously read [`Mstatus`] value, but does not
     /// affect the mstatus CSR itself.
     #[inline]
-    pub fn set_xs(&self, xs: XS) -> Self {
-        self.bf_insert(15, 2, xs as usize)
+    pub fn set_xs(&mut self, xs: XS) {
+        self.bits = bf_insert(self.bits, 15, 2, xs as usize);
     }
 
     /// Modify Memory PRiVilege
     #[inline]
     pub fn mprv(&self) -> bool {
-        self.bf_extract(17, 1) != 0
+        bf_extract(self.bits, 17, 1) != 0
     }
 
     /// Update Modify Memory PRiVilege
@@ -277,14 +263,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_mprv`]/[`clear_mprv`] to
     /// directly update the CSR.
     #[inline]
-    pub fn set_mprv(&self, mprv: bool) -> Self {
-        self.bf_insert(17, 1, mprv as usize)
+    pub fn set_mprv(&mut self, mprv: bool) {
+        self.bits = bf_insert(self.bits, 17, 1, mprv as usize);
     }
 
     /// Permit Supervisor User Memory access
     #[inline]
     pub fn sum(&self) -> bool {
-        self.bf_extract(18, 1) != 0
+        bf_extract(self.bits, 18, 1) != 0
     }
 
     /// Update Permit Supervisor User Memory access
@@ -293,14 +279,14 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_sum`]/[`clear_sum`] to directly
     /// update the CSR.
     #[inline]
-    pub fn set_sum(&self, sum: bool) -> Self {
-        self.bf_insert(18, 1, sum as usize)
+    pub fn set_sum(&mut self, sum: bool) {
+        self.bits = bf_insert(self.bits, 18, 1, sum as usize);
     }
 
     /// Make eXecutable Readable
     #[inline]
     pub fn mxr(&self) -> bool {
-        self.bf_extract(19, 1) != 0
+        bf_extract(self.bits, 19, 1) != 0
     }
 
     /// Update Make eXecutable Readable
@@ -309,8 +295,8 @@ impl Mstatus {
     /// the mstatus CSR itself. See [`set_mxr`]/[`clear_mxr`] to directly update
     /// the CSR.
     #[inline]
-    pub fn set_mxr(&self, mxr: bool) -> Self {
-        self.bf_insert(19, 1, mxr as usize)
+    pub fn set_mxr(&mut self, mxr: bool) {
+        self.bits = bf_insert(self.bits, 19, 1, mxr as usize);
     }
 
     /// Trap Virtual Memory
@@ -321,7 +307,7 @@ impl Mstatus {
     /// TVM is hard-wired to 0 when S-mode is not supported.
     #[inline]
     pub fn tvm(&self) -> bool {
-        self.bf_extract(20, 1) != 0
+        bf_extract(self.bits, 20, 1) != 0
     }
 
     /// Update Trap Virtual Memory
@@ -330,8 +316,8 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_tvm`]/[`clear_tvm`] to directly
     /// update the CSR.
     #[inline]
-    pub fn set_tvm(&self, tvm: bool) -> Self {
-        self.bf_insert(20, 1, tvm as usize)
+    pub fn set_tvm(&mut self, tvm: bool) {
+        self.bits = bf_insert(self.bits, 20, 1, tvm as usize);
     }
 
     /// Timeout Wait
@@ -345,7 +331,7 @@ impl Mstatus {
     /// TW is hard-wired to 0 when S-mode is not supported.
     #[inline]
     pub fn tw(&self) -> bool {
-        self.bf_extract(21, 1) != 0
+        bf_extract(self.bits, 21, 1) != 0
     }
 
     /// Update Timeout Wait
@@ -354,8 +340,8 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_tw`]/[`clear_tw`] to directly
     /// update the CSR.
     #[inline]
-    pub fn set_tw(&self, tw: bool) -> Self {
-        self.bf_insert(21, 1, tw as usize)
+    pub fn set_tw(&mut self, tw: bool) {
+        self.bits = bf_insert(self.bits, 21, 1, tw as usize);
     }
 
     /// Trap SRET
@@ -366,7 +352,7 @@ impl Mstatus {
     /// If S-mode is not supported, TSR bit is hard-wired to 0.
     #[inline]
     pub fn tsr(&self) -> bool {
-        self.bf_extract(22, 1) != 0
+        bf_extract(self.bits, 22, 1) != 0
     }
 
     /// Update Trap SRET
@@ -375,8 +361,8 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_tsr`]/[`clear_tsr`] to directly
     /// update the CSR.
     #[inline]
-    pub fn set_tsr(&self, tsr: bool) -> Self {
-        self.bf_insert(22, 1, tsr as usize)
+    pub fn set_tsr(&mut self, tsr: bool) {
+        self.bits = bf_insert(self.bits, 22, 1, tsr as usize);
     }
 
     /// Effective xlen in U-mode (i.e., `UXLEN`).
@@ -388,7 +374,7 @@ impl Mstatus {
             #[cfg(riscv32)]
             () => XLEN::XLEN32,
             #[cfg(not(riscv32))]
-            () => XLEN::from(self.bf_extract(32, 2) as u8),
+            () => XLEN::from(bf_extract(self.bits, 32, 2) as u8),
         }
     }
 
@@ -397,13 +383,11 @@ impl Mstatus {
     /// Note this updates a previously read [`Mstatus`] value, but does not
     /// affect the mstatus CSR itself.
     #[inline]
-    pub fn set_uxl(&self, uxl: XLEN) -> Self {
-        #[cfg(riscv32)]
-        {
-            *self
-        }
+    pub fn set_uxl(&mut self, uxl: XLEN) {
         #[cfg(not(riscv32))]
-        self.bf_insert(32, 2, uxl as usize)
+        {
+            self.bits = bf_insert(self.bits, 32, 2, uxl as usize);
+        }
     }
 
     /// Effective xlen in S-mode (i.e., `SXLEN`).
@@ -415,7 +399,7 @@ impl Mstatus {
             #[cfg(riscv32)]
             () => XLEN::XLEN32,
             #[cfg(not(riscv32))]
-            () => XLEN::from(self.bf_extract(34, 2) as u8),
+            () => XLEN::from(bf_extract(self.bits, 34, 2) as u8),
         }
     }
 
@@ -424,13 +408,11 @@ impl Mstatus {
     /// Note this updates a previously read [`Mstatus`] value, but does not
     /// affect the mstatus CSR itself.
     #[inline]
-    pub fn set_sxl(&self, sxl: XLEN) -> Self {
-        #[cfg(riscv32)]
-        {
-            *self
-        }
+    pub fn set_sxl(&mut self, sxl: XLEN) {
         #[cfg(not(riscv32))]
-        self.bf_insert(34, 2, sxl as usize)
+        {
+            self.bits = bf_insert(self.bits, 34, 2, sxl as usize);
+        }
     }
 
     /// S-mode non-instruction-fetch memory endianness.
@@ -441,7 +423,7 @@ impl Mstatus {
             #[cfg(riscv32)]
             () => super::mstatush::read().sbe(),
             #[cfg(not(riscv32))]
-            () => Endianness::from(self.bf_extract(36, 1) != 0),
+            () => Endianness::from(bf_extract(self.bits, 36, 1) != 0),
         }
     }
 
@@ -451,13 +433,11 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_sbe`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_sbe(&self, endianness: Endianness) -> Self {
-        #[cfg(riscv32)]
-        {
-            *self
-        }
+    pub fn set_sbe(&mut self, endianness: Endianness) {
         #[cfg(not(riscv32))]
-        self.bf_insert(36, 1, endianness as usize)
+        {
+            self.bits = bf_insert(self.bits, 36, 1, endianness as usize);
+        }
     }
 
     /// M-mode non-instruction-fetch memory endianness
@@ -468,7 +448,7 @@ impl Mstatus {
             #[cfg(riscv32)]
             () => super::mstatush::read().mbe(),
             #[cfg(not(riscv32))]
-            () => Endianness::from(self.bf_extract(37, 1) != 0),
+            () => Endianness::from(bf_extract(self.bits, 37, 1) != 0),
         }
     }
     /// Update M-mode non-instruction-fetch memory endianness
@@ -477,19 +457,17 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_mbe`] to directly update the
     /// CSR.
     #[inline]
-    pub fn set_mbe(&self, endianness: Endianness) -> Self {
-        #[cfg(riscv32)]
-        {
-            *self
-        }
+    pub fn set_mbe(&mut self, endianness: Endianness) {
         #[cfg(not(riscv32))]
-        self.bf_insert(37, 1, endianness as usize)
+        {
+            self.bits = bf_insert(self.bits, 37, 1, endianness as usize);
+        }
     }
 
     /// Whether either the FS field or XS field signals the presence of some dirty state
     #[inline]
     pub fn sd(&self) -> bool {
-        self.bf_extract(usize::BITS as usize - 1, 1) != 0
+        bf_extract(self.bits, usize::BITS as usize - 1, 1) != 0
     }
 
     /// Update whether either the FS field or XS field signals the presence of
@@ -498,8 +476,8 @@ impl Mstatus {
     /// Note this updates a previously read [`Mstatus`] value, but does not
     /// affect the mstatus CSR itself.
     #[inline]
-    pub fn set_sd(&self, sd: bool) -> Self {
-        self.bf_insert(usize::BITS as usize - 1, 1, sd as usize)
+    pub fn set_sd(&mut self, sd: bool) {
+        self.bits = bf_insert(self.bits, usize::BITS as usize - 1, 1, sd as usize);
     }
 }
 

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -72,6 +72,15 @@ impl From<bool> for Endianness {
 }
 
 impl Mstatus {
+    /// Helper to insert a bitfield into Mstatus
+    #[inline]
+    fn bf_insert(&self, bit: usize, width: usize, val: usize) -> Self {
+        let mask = (1 << width) - 1;
+        Self {
+            bits: self.bits & !(mask << bit) | ((val & mask) << bit),
+        }
+    }
+
     /// Returns the contents of the register as raw bits
     #[inline]
     pub fn bits(&self) -> usize {
@@ -84,10 +93,22 @@ impl Mstatus {
         self.bits & (1 << 1) != 0
     }
 
+    /// Set Supervisor Interrupt Enable
+    #[inline]
+    pub fn set_sie(&self, sie: bool) -> Self {
+        self.bf_insert(1, 1, sie as usize)
+    }
+
     /// Machine Interrupt Enable
     #[inline]
     pub fn mie(&self) -> bool {
         self.bits & (1 << 3) != 0
+    }
+
+    /// Set Machine Interrupt Enable
+    #[inline]
+    pub fn set_mie(&self, mie: bool) -> Self {
+        self.bf_insert(3, 1, mie as usize)
     }
 
     /// Supervisor Previous Interrupt Enable
@@ -96,16 +117,34 @@ impl Mstatus {
         self.bits & (1 << 5) != 0
     }
 
+    /// Supervisor Previous Interrupt Enable
+    #[inline]
+    pub fn set_spie(&self, spie: bool) -> Self {
+        self.bf_insert(5, 1, spie as usize)
+    }
+
     /// U-mode non-instruction-fetch memory endianness
     #[inline]
     pub fn ube(&self) -> Endianness {
         Endianness::from(self.bits & (1 << 6) != 0)
     }
 
+    /// Set U-mode non-instruction-fetch memory endianness
+    #[inline]
+    pub fn set_ube(&self, endianness: Endianness) -> Self {
+        self.bf_insert(6, 1, endianness as usize)
+    }
+
     /// Machine Previous Interrupt Enable
     #[inline]
     pub fn mpie(&self) -> bool {
         self.bits & (1 << 7) != 0
+    }
+
+    /// Set Machine Previous Interrupt Enable
+    #[inline]
+    pub fn set_mpie(&self, mpie: bool) -> Self {
+        self.bf_insert(7, 1, mpie as usize)
     }
 
     /// Supervisor Previous Privilege Mode
@@ -115,6 +154,12 @@ impl Mstatus {
             true => SPP::Supervisor,
             false => SPP::User,
         }
+    }
+
+    /// Set Supervisor Previous Privilege Mode
+    #[inline]
+    pub fn set_spp(&self, spp: SPP) -> Self {
+        self.bf_insert(8, 1, spp as usize)
     }
 
     /// Machine Previous Privilege Mode
@@ -127,6 +172,12 @@ impl Mstatus {
             0b11 => MPP::Machine,
             _ => unreachable!(),
         }
+    }
+
+    /// Set Machine Previous Privilege Mode
+    #[inline]
+    pub fn set_mpp(&self, mpp: MPP) -> Self {
+        self.bf_insert(11, 2, mpp as usize)
     }
 
     /// Floating-point extension state
@@ -145,6 +196,12 @@ impl Mstatus {
         }
     }
 
+    /// Set Floating-point extension state
+    #[inline]
+    pub fn set_fs(&self, fs: FS) -> Self {
+        self.bf_insert(13, 2, fs as usize)
+    }
+
     /// Additional extension state
     ///
     /// Encodes the status of additional user-mode extensions and associated state.
@@ -160,10 +217,22 @@ impl Mstatus {
         }
     }
 
+    /// Set Additional extension state
+    #[inline]
+    pub fn set_xs(&self, xs: XS) -> Self {
+        self.bf_insert(15, 2, xs as usize)
+    }
+
     /// Modify Memory PRiVilege
     #[inline]
     pub fn mprv(&self) -> bool {
         self.bits & (1 << 17) != 0
+    }
+
+    /// Set Modify Memory PRiVilege
+    #[inline]
+    pub fn set_mprv(&self, mprv: bool) -> Self {
+        self.bf_insert(17, 1, mprv as usize)
     }
 
     /// Permit Supervisor User Memory access
@@ -172,10 +241,22 @@ impl Mstatus {
         self.bits & (1 << 18) != 0
     }
 
+    /// Set Permit Supervisor User Memory access
+    #[inline]
+    pub fn set_sum(&self, sum: bool) -> Self {
+        self.bf_insert(18, 1, sum as usize)
+    }
+
     /// Make eXecutable Readable
     #[inline]
     pub fn mxr(&self) -> bool {
         self.bits & (1 << 19) != 0
+    }
+
+    /// Set Make eXecutable Readable
+    #[inline]
+    pub fn set_mxr(&self, mxr: bool) -> Self {
+        self.bf_insert(19, 1, mxr as usize)
     }
 
     /// Trap Virtual Memory
@@ -187,6 +268,12 @@ impl Mstatus {
     #[inline]
     pub fn tvm(&self) -> bool {
         self.bits & (1 << 20) != 0
+    }
+
+    /// Set Trap Virtual Memory
+    #[inline]
+    pub fn set_tvm(&self, tvm: bool) -> Self {
+        self.bf_insert(20, 1, tvm as usize)
     }
 
     /// Timeout Wait
@@ -203,6 +290,12 @@ impl Mstatus {
         self.bits & (1 << 21) != 0
     }
 
+    /// Set Timeout Wait
+    #[inline]
+    pub fn set_tw(&self, tw: bool) -> Self {
+        self.bf_insert(21, 1, tw as usize)
+    }
+
     /// Trap SRET
     ///
     /// Indicates that if SRET instruction should be trapped to raise illegal
@@ -212,6 +305,12 @@ impl Mstatus {
     #[inline]
     pub fn tsr(&self) -> bool {
         self.bits & (1 << 22) != 0
+    }
+
+    /// Set Trap SRET
+    #[inline]
+    pub fn set_tsr(&self, tsr: bool) -> Self {
+        self.bf_insert(22, 1, tsr as usize)
     }
 
     /// Effective xlen in U-mode (i.e., `UXLEN`).
@@ -227,6 +326,17 @@ impl Mstatus {
         }
     }
 
+    /// Set Effective xlen in U-mode (i.e., `UXLEN`).
+    #[inline]
+    pub fn set_uxl(&self, uxl: XLEN) -> Self {
+        #[cfg(riscv32)]
+        {
+            *self
+        }
+        #[cfg(not(riscv32))]
+        self.bf_insert(32, 2, uxl as usize)
+    }
+
     /// Effective xlen in S-mode (i.e., `SXLEN`).
     ///
     /// In RISCV-32, SXL does not exist, and SXLEN is always [`XLEN::XLEN32`].
@@ -238,6 +348,17 @@ impl Mstatus {
             #[cfg(not(riscv32))]
             () => XLEN::from((self.bits >> 34) as u8 & 0x3),
         }
+    }
+
+    /// Set Effective xlen in S-mode (i.e., `SXLEN`).
+    #[inline]
+    pub fn set_sxl(&self, sxl: XLEN) -> Self {
+        #[cfg(riscv32)]
+        {
+            *self
+        }
+        #[cfg(not(riscv32))]
+        self.bf_insert(34, 2, sxl as usize)
     }
 
     /// S-mode non-instruction-fetch memory endianness.
@@ -252,6 +373,17 @@ impl Mstatus {
         }
     }
 
+    /// Set S-mode non-instruction-fetch memory endianness
+    #[inline]
+    pub fn set_sbe(&self, endianness: Endianness) -> Self {
+        #[cfg(riscv32)]
+        {
+            *self
+        }
+        #[cfg(not(riscv32))]
+        self.bf_insert(36, 1, endianness as usize)
+    }
+
     /// M-mode non-instruction-fetch memory endianness
     ///
     /// In RISCV-32, this field is read from the [`crate::register::mstatush`] register
@@ -264,10 +396,26 @@ impl Mstatus {
         }
     }
 
+    /// Set M-mode non-instruction-fetch memory endianness
+    pub fn set_mbe(&self, endianness: Endianness) -> Self {
+        #[cfg(riscv32)]
+        {
+            *self
+        }
+        #[cfg(not(riscv32))]
+        self.bf_insert(37, 1, endianness as usize)
+    }
+
     /// Whether either the FS field or XS field signals the presence of some dirty state
     #[inline]
     pub fn sd(&self) -> bool {
         self.bits & (1 << (usize::BITS as usize - 1)) != 0
+    }
+
+    /// Set whether either the FS field or XS field signals the presence of some dirty state
+    #[inline]
+    pub fn set_sd(&self, sd: bool) -> Self {
+        self.bf_insert(usize::BITS as usize - 1, 1, sd as usize)
     }
 }
 


### PR DESCRIPTION
Without needing to touch the CSR. This allows multiple changes in a single register write.