### PR TITLE
Align jump targets to 4 bytes

### DIFF
--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -483,12 +483,14 @@ fn vectored_interrupt_trap(arch: RiscvArch) -> TokenStream {
 core::arch::global_asm!(
 ".section .trap, \"ax\"
 
+.align 4
 .global _start_DefaultHandler_trap
 _start_DefaultHandler_trap:
     addi sp, sp, -{TRAP_SIZE} * {width} // allocate space for trap frame
     {store_start}                       // store trap partially (only register a0)
     la a0, DefaultHandler               // load interrupt handler address into a0
 
+.align 4
 .global _continue_interrupt_trap
 _continue_interrupt_trap:
     {store_continue}                   // store trap partially (all registers except a0)


### PR DESCRIPTION
While testing the new v-trap implementation from https://github.com/rust-embedded/riscv/pull/200 I noticed that upon trapping a vectored interrupt, the program counter ends up halfway between instructions right before `_start_DefaultHandler_trap` causing an illegal instruction exception.

The cause seems to be that this location (`_start_DefaultHandler_trap`) is reached via direct unconditional jump in `_continue_interrupt_trap` and the jump instruction is taken at 4-byte alignment. Setting these symbols to .align 4 fixes the problem on our (custom) machine.

I think it's a feature of RISC-V unconditional jumps that they can't express addresses below 4-byte alignment but it could be a feature(bug) of our machine as well. I'm a bit confused about this still because the disassembly shows the correct target `j       119a <_start_DefaultHandler_trap>` while the machine ends up jumping to `1198` and failing.