### PR TITLE
riscv: add `mcountinhibit` module

### DIFF
--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `clippy` fixes
+
 ## [v0.1.0] - 2024-02-15
 
 ### Added

--- a/riscv-peripheral/src/lib.rs
+++ b/riscv-peripheral/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Features
 //!
 //! - `aclint-hal-async`: enables the [`hal_async::delay::DelayNs`] implementation for the ACLINT peripheral.
-//! This feature relies on external functions that must be provided by the user. See [`hal_async::aclint`] for more information.
+//!   This feature relies on external functions that must be provided by the user. See [`hal_async::aclint`] for more information.
 
 #![deny(missing_docs)]
 #![no_std]

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Mstatus::update_*` helpers to manipulate Mstatus values without touching
   the CSR
 - Export `riscv::register::macros` module macros for external use
+- Add `riscv::register::mcountinhibit` module for `mcountinhibit` CSR
 
 ### Fixed
 

--- a/riscv/src/interrupt.rs
+++ b/riscv/src/interrupt.rs
@@ -62,7 +62,7 @@ pub mod machine {
     /// - Do not call this function inside a critical section.
     /// - This method is assumed to be called within an interrupt handler.
     /// - Make sure to clear the interrupt flag that caused the interrupt before calling
-    /// this method. Otherwise, the interrupt will be re-triggered before executing `f`.
+    ///   this method. Otherwise, the interrupt will be re-triggered before executing `f`.
     #[inline]
     pub unsafe fn nested<F, R>(f: F) -> R
     where
@@ -151,7 +151,7 @@ pub mod supervisor {
     /// - Do not call this function inside a critical section.
     /// - This method is assumed to be called within an interrupt handler.
     /// - Make sure to clear the interrupt flag that caused the interrupt before calling
-    /// this method. Otherwise, the interrupt will be re-triggered before executing `f`.
+    ///   this method. Otherwise, the interrupt will be re-triggered before executing `f`.
     #[inline]
     pub unsafe fn nested<F, R>(f: F) -> R
     where

--- a/riscv/src/register.rs
+++ b/riscv/src/register.rs
@@ -95,6 +95,7 @@ mod pmpaddrx;
 pub use self::pmpaddrx::*;
 
 // Machine Counter/Timers
+pub mod mcountinhibit;
 pub mod mcycle;
 pub mod mcycleh;
 mod mhpmcounterx;

--- a/riscv/src/register/mcountinhibit.rs
+++ b/riscv/src/register/mcountinhibit.rs
@@ -1,0 +1,116 @@
+//! `mcountinhibit` register
+
+use crate::bits::{bf_extract, bf_insert};
+
+/// `mcountinhibit` register
+#[derive(Clone, Copy, Debug)]
+pub struct Mcountinhibit {
+    bits: usize,
+}
+
+impl Mcountinhibit {
+    /// Machine "cycle\[h\]" Disable
+    #[inline]
+    pub fn cy(&self) -> bool {
+        bf_extract(self.bits, 0, 1) != 0
+    }
+
+    /// Sets whether to inhibit the "cycle\[h\]" counter.
+    ///
+    /// Only updates the in-memory value, does not modify the `mcountinhibit` register.
+    #[inline]
+    pub fn set_cy(&mut self, cy: bool) {
+        self.bits = bf_insert(self.bits, 0, 1, cy as usize);
+    }
+
+    /// Machine "instret\[h\]" Disable
+    #[inline]
+    pub fn ir(&self) -> bool {
+        bf_extract(self.bits, 2, 1) != 0
+    }
+
+    /// Sets whether to inhibit the "instret\[h\]" counter.
+    ///
+    /// Only updates the in-memory value, does not modify the `mcountinhibit` register.
+    #[inline]
+    pub fn set_ir(&mut self, ir: bool) {
+        self.bits = bf_insert(self.bits, 2, 1, ir as usize);
+    }
+
+    /// Machine "hpm\[x\]" Disable (bits 3-31)
+    #[inline]
+    pub fn hpm(&self, index: usize) -> bool {
+        assert!((3..32).contains(&index));
+        bf_extract(self.bits, index, 1) != 0
+    }
+
+    /// Sets whether to inhibit the "hpm\[X\]" counter.
+    ///
+    /// Only updates the in-memory value, does not modify the `mcountinhibit` register.
+    #[inline]
+    pub fn set_hpm(&mut self, index: usize, hpm: bool) {
+        assert!((3..32).contains(&index));
+        self.bits = bf_insert(self.bits, index, 1, hpm as usize);
+    }
+}
+
+read_csr_as!(Mcountinhibit, 0x320);
+write_csr_as!(Mcountinhibit, 0x320);
+set!(0x320);
+clear!(0x320);
+
+set_clear_csr!(
+/// Machine cycle Disable
+    , set_cy, clear_cy, 1 << 0);
+
+set_clear_csr!(
+/// Machine instret Disable
+    , set_ir, clear_ir, 1 << 2);
+
+#[inline]
+pub unsafe fn set_hpm(index: usize) {
+    assert!((3..32).contains(&index));
+    _set(1 << index);
+}
+
+#[inline]
+pub unsafe fn clear_hpm(index: usize) {
+    assert!((3..32).contains(&index));
+    _clear(1 << index);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mcountinhibit() {
+        let mut m = Mcountinhibit { bits: 0 };
+
+        assert!(!m.cy());
+
+        m.set_cy(true);
+        assert!(m.cy());
+
+        m.set_cy(false);
+        assert!(!m.cy());
+
+        assert!(!m.ir());
+
+        m.set_ir(true);
+        assert!(m.ir());
+
+        m.set_ir(false);
+        assert!(!m.ir());
+
+        (3..32).for_each(|i| {
+            assert!(!m.hpm(i));
+
+            m.set_hpm(i, true);
+            assert!(m.hpm(i));
+
+            m.set_hpm(i, false);
+            assert!(!m.hpm(i));
+        });
+    }
+}


### PR DESCRIPTION
Adds the `riscv::register::mcountinhibit` module for the `mcountinhibit` CSR.