### PR TITLE
fixup: riscv: fix `mstatus` test

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed `sip::set_ssoft` and `sip::clear_ssoft` using wrong address
+- Fixed assignment in `mstatus` unit tests.
 
 ## [v0.11.1] - 2024-02-15
 

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -602,11 +602,11 @@ mod test {
     #[test]
     fn test_mpp() {
         let mut mstatus = Mstatus { bits: 0 };
-        mstatus = mstatus.set_mpp(MPP::User);
+        mstatus.set_mpp(MPP::User);
         assert_eq!(mstatus.mpp(), MPP::User);
-        mstatus = mstatus.set_mpp(MPP::Machine);
+        mstatus.set_mpp(MPP::Machine);
         assert_eq!(mstatus.mpp(), MPP::Machine);
-        mstatus = mstatus.set_mpp(MPP::Supervisor);
+        mstatus.set_mpp(MPP::Supervisor);
         assert_eq!(mstatus.mpp(), MPP::Supervisor);
     }
 }


### PR DESCRIPTION
Fixes the assignment in the `mstatus` unti tests.