### PR TITLE
Fix semihosting::debug::exit() on riscv64 QEMU targets.

### DIFF
--- a/riscv-semihosting/CHANGELOG.md
+++ b/riscv-semihosting/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Made `cfg` variable selection more robust for custom targets
+- Fixed debug::exit() on riscv64 QEMU simulation
 
 ## [v0.1.0] - 2023-01-18
 

--- a/riscv-semihosting/src/debug.rs
+++ b/riscv-semihosting/src/debug.rs
@@ -89,6 +89,10 @@ pub fn exit(status: ExitStatus) {
 pub fn report_exception(reason: Exception) {
     let code = reason as usize;
     unsafe {
+        #[cfg(target_arch = "riscv64")]
+        syscall!(REPORT_EXCEPTION, code, 0);
+
+        #[cfg(not(target_arch = "riscv64"))]
         syscall1!(REPORT_EXCEPTION, code);
     }
 }


### PR DESCRIPTION
QEMU's handler for REPORT_EXCEPTION (a.k.a. TARGET_SYS_EXIT in QEMU sources) expects two arguments for 64-bit systems, including riscv64. In the event that a second argument is not provided, QEMU takes an error path which does *not* exit the simulation.

The net result is that semihosting::debug::exit() hangs on riscv64 qemu simulation.

Provide the necessary extra parameter to the syscall so that exit now works properly.

Note that the second parameter only affects the simulator exit code if the first parameter is ApplicationExit, and we use ApplicationExit only for successful exit, so we can simply hardcode 0 as second parameter. On the error path we set first parameter to RunTimeErrorUnknown and QEMU properly returns exit code 1 regardless of second parameter

.Note: tested for both rv32 and rv64 targets with https://github.com/kevin-vigor/test-riscv-semihosting-exit