### PR TITLE
riscv-rt-macros: update syn to v2.0

### DIFF
--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.60.0
-        toolchain: [ stable, nightly, 1.60.0 ]
+        # All generated code should be running on stable now, MRSV is 1.61.0
+        toolchain: [ stable, nightly, 1.61.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -23,6 +23,7 @@ If `v-trap` feature is enabled, this macro also generates its corresponding trap
 - `_start_trap_rust` now only deals with exceptions. When an interrupt is detected, it now calls
 to `_dispatch_interrupt`.
 - Upgrade rust-version to 1.61
+- Update `syn` to version 2.0
 
 ### Removed
 

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -22,6 +22,7 @@ If `v-trap` feature is enabled, this macro also generates its corresponding trap
 - Made `cfg` variable selection more robust for custom targets
 - `_start_trap_rust` now only deals with exceptions. When an interrupt is detected, it now calls
 to `_dispatch_interrupt`.
+- Upgrade rust-version to 1.61
 
 ### Removed
 

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "riscv-rt"
 version = "0.13.0"
-rust-version = "1.60"
+rust-version = "1.61"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]

--- a/riscv-rt/README.md
+++ b/riscv-rt/README.md
@@ -11,7 +11,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.61 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/riscv-rt/macros/Cargo.toml
+++ b/riscv-rt/macros/Cargo.toml
@@ -18,10 +18,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"
-
-[dependencies.syn]
-version = "1.0"
-features = ["extra-traits", "full"]
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 
 [features]
 s-mode = []

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.61 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 //!
 //! # Features


### PR DESCRIPTION
Upgrade `syn` in order to deduplicate dependencies in projects depending on `riscv-rt`, as most other crates have upgraded to version 2.
Tested by building and flashing a simple hello world to the ESP32-C3, with no difference between the two versions.

While syn's [README](https://github.com/dtolnay/syn/blob/master/README.md) states `Version requirement: Syn supports rustc 1.61 and up.`, riscv-rt-macros still builds with `1.59`.