### PR TITLE
riscv-semihosting: fix ambiguous documentation link

### DIFF
--- a/riscv-semihosting/CHANGELOG.md
+++ b/riscv-semihosting/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Made `cfg` variable selection more robust for custom targets
 - Fixed debug::exit() on riscv64 QEMU simulation
+- Fixed an ambiguous link in the generated crate documentation.
 
 ## [v0.1.0] - 2023-01-18
 

--- a/riscv-semihosting/src/lib.rs
+++ b/riscv-semihosting/src/lib.rs
@@ -209,7 +209,7 @@ pub unsafe fn syscall<T>(nr: usize, arg: &T) -> usize {
 ///
 /// # Safety
 ///
-/// Same as [`syscall`].
+/// Same as [`syscall()`].
 #[inline(always)]
 pub unsafe fn syscall1(_nr: usize, _arg: usize) -> usize {
     match () {


### PR DESCRIPTION
Fix the following warning when generating the crate documentation:

```
warning: `syscall` is both a function and a macro
   --> riscv-semihosting/src/lib.rs:212:15
    |
212 | /// Same as [`syscall`].
    |               ^^^^^^^ ambiguous link
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
help: to link to the function, add parentheses
    |
212 | /// Same as [`syscall()`].
    |                      ++
help: to link to the macro, add an exclamation mark
    |
212 | /// Same as [`syscall!`].
    |                      +
```