### PR TITLE
riscv: fix mtvec address field

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `sip::set_ssoft` and `sip::clear_ssoft` using wrong address
 - Fixed assignment in `mstatus` unit tests.
+- Fixed address field for `mtvec`
 
 ## [v0.11.1] - 2024-02-15
 

--- a/riscv/src/register/mtvec.rs
+++ b/riscv/src/register/mtvec.rs
@@ -23,7 +23,7 @@ impl Mtvec {
     /// Returns the trap-vector base-address
     #[inline]
     pub fn address(&self) -> usize {
-        self.bits - (self.bits & 0b11)
+        self.bits >> 2
     }
 
     /// Returns the trap-vector mode
@@ -45,6 +45,6 @@ write_csr!(0x305);
 /// Writes the CSR
 #[inline]
 pub unsafe fn write(addr: usize, mode: TrapMode) {
-    let bits = addr + mode as usize;
+    let bits = (addr << 2) | mode as usize;
     _write(bits);
 }


### PR DESCRIPTION
The `address` (BASE from the spec) needs to be 4-byte aligned, but the spec does not specify that the field is read/written as the masked address.

Shifts the value in `mtvec::write(addr, mode)`, and `Mtvec::address` for a more intuitive API.