### PR TITLE
Make support for u-boot

### DIFF
--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -42,7 +42,7 @@ jobs:
       - name : Build (v-trap)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=v-trap
       - name: Build (all features)
-        run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --all-features
+        run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=s-mode,signle-hart,v-trap
 
   # Job to check that all the builds succeeded
   build-check:

--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -42,7 +42,7 @@ jobs:
       - name : Build (v-trap)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=v-trap
       - name: Build (all features)
-        run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=s-mode,signle-hart,v-trap
+        run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=s-mode,single-hart,v-trap
 
   # Job to check that all the builds succeeded
   build-check:

--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -41,8 +41,10 @@ jobs:
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=single-hart
       - name : Build (v-trap)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=v-trap
-      - name: Build (all features)
+      - name : Build (all features except u-boot)
         run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example ${{ matrix.example }} --features=s-mode,single-hart,v-trap
+      - name : Build (u-boot)
+        run: RUSTFLAGS="-C link-arg=-Triscv-rt/examples/device.x" cargo build --package riscv-rt --target ${{ matrix.target }} --example empty --features=u-boot
 
   # Job to check that all the builds succeeded
   build-check:

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `v-trap` feature to enable interrupt handling in vectored mode.
 - Add `interrupt` proc macro to help defining interrupt handlers.
 If `v-trap` feature is enabled, this macro also generates its corresponding trap.
+- Add `u-boot` feature, so that you can start your elf binary with u-boot and
+work with passed arguments.
 
 ### Changed
 

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -23,3 +23,4 @@ panic-halt = "0.2.0"
 s-mode = ["riscv-rt-macros/s-mode"]
 single-hart = []
 v-trap = ["riscv-rt-macros/v-trap"]
+u-boot = ["riscv-rt-macros/u-boot"]

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -23,4 +23,4 @@ panic-halt = "0.2.0"
 s-mode = ["riscv-rt-macros/s-mode"]
 single-hart = []
 v-trap = ["riscv-rt-macros/v-trap"]
-u-boot = ["riscv-rt-macros/u-boot"]
+u-boot = ["riscv-rt-macros/u-boot", "single-hart"]

--- a/riscv-rt/macros/Cargo.toml
+++ b/riscv-rt/macros/Cargo.toml
@@ -23,3 +23,4 @@ syn = { version = "2.0", features = ["extra-traits", "full"] }
 [features]
 s-mode = []
 v-trap = []
+u-boot = []

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -53,6 +53,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     let f = parse_macro_input!(input as ItemFn);
 
     // check the function arguments
+    #[cfg(not(feature = "u-boot"))]
     if f.sig.inputs.len() > 3 {
         return parse::Error::new(
             f.sig.inputs.last().unwrap().span(),
@@ -61,10 +62,55 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         .to_compile_error()
         .into();
     }
+    #[cfg(feature = "u-boot")]
+    if f.sig.inputs.len() != 2 {
+        return parse::Error::new(
+            f.sig.inputs.last().unwrap().span(),
+            "`#[entry]` function must have exactly two arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    #[cfg(not(feature = "u-boot"))]
     for arg in &f.sig.inputs {
         match arg {
             FnArg::Receiver(_) => {
                 return parse::Error::new(arg.span(), "invalid argument")
+                    .to_compile_error()
+                    .into();
+            }
+            FnArg::Typed(t) => {
+                if !is_simple_type(&t.ty, "usize") {
+                    return parse::Error::new(t.ty.span(), "argument type must be usize")
+                        .to_compile_error()
+                        .into();
+                }
+            }
+        }
+    }
+    #[cfg(feature = "u-boot")]
+    {
+        // We have checked that there are two arguments above.
+        let (a1, a2) = (&f.sig.inputs[0], &f.sig.inputs[1]);
+
+        match a1 {
+            FnArg::Receiver(_) => {
+                return parse::Error::new(a1.span(), "invalid argument")
+                    .to_compile_error()
+                    .into();
+            }
+            FnArg::Typed(t) => {
+                if !is_simple_type(&t.ty, "c_int") {
+                    return parse::Error::new(t.ty.span(), "argument type must be c_int")
+                        .to_compile_error()
+                        .into();
+                }
+            }
+        }
+        match a2 {
+            FnArg::Receiver(_) => {
+                return parse::Error::new(a2.span(), "invalid argument")
                     .to_compile_error()
                     .into();
             }

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -549,15 +549,21 @@ _continue_interrupt_trap:
 }
 
 #[proc_macro_attribute]
-/// Attribute to declare an interrupt handler. The function must have the signature `[unsafe] fn() [-> !]`.
-/// If the `v-trap` feature is enabled, this macro generates the interrupt trap handler in assembly for RISCV-32 targets.
+/// Attribute to declare an interrupt handler.
+///
+/// The function must have the signature `[unsafe] fn() [-> !]`.
+/// If the `v-trap` feature is enabled, this macro generates the
+/// interrupt trap handler in assembly for RISCV-32 targets.
 pub fn interrupt_riscv32(args: TokenStream, input: TokenStream) -> TokenStream {
     interrupt(args, input, RiscvArch::Rv32)
 }
 
 #[proc_macro_attribute]
-/// Attribute to declare an interrupt handler. The function must have the signature `[unsafe] fn() [-> !]`.
-/// If the `v-trap` feature is enabled, this macro generates the interrupt trap handler in assembly for RISCV-32 targets.
+/// Attribute to declare an interrupt handler.
+///
+/// The function must have the signature `[unsafe] fn() [-> !]`.
+/// If the `v-trap` feature is enabled, this macro generates the
+/// interrupt trap handler in assembly for RISCV-64 targets.
 pub fn interrupt_riscv64(args: TokenStream, input: TokenStream) -> TokenStream {
     interrupt(args, input, RiscvArch::Rv64)
 }

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -125,7 +125,6 @@ cfg_global_asm!(
 );
 
 // STORE A0..A2 IN THE STACK, AS THEY WILL BE NEEDED LATER BY main
-#[cfg(not(feature = "u-boot"))]
 cfg_global_asm!(
     #[cfg(riscv32)]
     "addi sp, sp, -4 * 3
@@ -214,12 +213,12 @@ riscv_rt_macros::loop_global_asm!("    fmv.w.x f{}, x0", 32);
 // SET UP INTERRUPTS, RESTORE a0..a2, AND JUMP TO MAIN RUST FUNCTION
 cfg_global_asm!(
     "call _setup_interrupts",
-    #[cfg(all(riscv32, not(feature = "u-boot")))]
+    #[cfg(riscv32)]
     "lw a0, 4 * 0(sp)
     lw a1, 4 * 1(sp)
     lw a2, 4 * 2(sp)
     addi sp, sp, 4 * 3",
-    #[cfg(all(riscv64, not(feature = "u-boot")))]
+    #[cfg(riscv64)]
     "ld a0, 8 * 0(sp)
     ld a1, 8 * 1(sp)
     ld a2, 8 * 2(sp)

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -125,6 +125,7 @@ cfg_global_asm!(
 );
 
 // STORE A0..A2 IN THE STACK, AS THEY WILL BE NEEDED LATER BY main
+#[cfg(not(feature = "u-boot"))]
 cfg_global_asm!(
     #[cfg(riscv32)]
     "addi sp, sp, -4 * 3
@@ -213,12 +214,12 @@ riscv_rt_macros::loop_global_asm!("    fmv.w.x f{}, x0", 32);
 // SET UP INTERRUPTS, RESTORE a0..a2, AND JUMP TO MAIN RUST FUNCTION
 cfg_global_asm!(
     "call _setup_interrupts",
-    #[cfg(riscv32)]
+    #[cfg(all(riscv32, not(feature = "u-boot")))]
     "lw a0, 4 * 0(sp)
     lw a1, 4 * 1(sp)
     lw a2, 4 * 2(sp)
     addi sp, sp, 4 * 3",
-    #[cfg(riscv64)]
+    #[cfg(all(riscv64, not(feature = "u-boot")))]
     "ld a0, 8 * 0(sp)
     ld a1, 8 * 1(sp)
     ld a2, 8 * 2(sp)

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -452,20 +452,19 @@
 //! ```
 //!
 //! This will generate a function named `_start_MachineTimer_trap` that calls the interrupt handler `MachineTimer`.
-//! 
+//!
 //! ## `u-boot`
-//! 
+//!
 //! The u-boot support feature (`u-boot`) can be activated via [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html).
-//! 
+//!
 //! For example:
 //! ``` text
 //! [dependencies]
 //! riscv-rt = { features = ["u-boot"] }
 //! ```
-//! When the u-boot feature is enabled, some assembly code is disabled to leave stack untouched. This is required
-//! because when booting from elf, u-boot passes arguments as argc and argv through stack. Because the only way
-//! to get boot-hart is through fdt, this feature also implies `single-hart` so other harts initialization
-//! is up to you.
+//! When the u-boot feature is enabled, acceptable signature for `#[entry]` macros is changed. This is required
+//! because when booting from elf, u-boot passes `argc` and `argv`. This feature also implies `single-hart`.
+//! The only way to get boot-hart is through fdt, so other harts initialization is up to you.
 
 // NOTE: Adapted from cortex-m/src/lib.rs
 #![no_std]

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -452,6 +452,20 @@
 //! ```
 //!
 //! This will generate a function named `_start_MachineTimer_trap` that calls the interrupt handler `MachineTimer`.
+//! 
+//! ## `u-boot`
+//! 
+//! The u-boot support feature (`u-boot`) can be activated via [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html).
+//! 
+//! For example:
+//! ``` text
+//! [dependencies]
+//! riscv-rt = { features = ["u-boot"] }
+//! ```
+//! When the u-boot feature is enabled, some assembly code is disabled to leave stack untouched. This is required
+//! because when booting from elf, u-boot passes arguments as argc and argv through stack. Because the only way
+//! to get boot-hart is through fdt, this feature also implies `single-hart` so other harts initialization
+//! is up to you.
 
 // NOTE: Adapted from cortex-m/src/lib.rs
 #![no_std]

--- a/riscv/src/interrupt.rs
+++ b/riscv/src/interrupt.rs
@@ -142,6 +142,7 @@ pub mod supervisor {
     }
 
     /// Execute closure `f` with interrupts enabled in the current hart (supervisor mode).
+    ///
     /// This method is assumed to be called within an interrupt handler, and allows
     /// nested interrupts to occur. After the closure `f` is executed, the [`sstatus`]
     /// and [`sepc`] registers are properly restored to their previous values.


### PR DESCRIPTION
U-Boot passes arguments through `int argc` and `char *const argv[]`. In order to work with them riscv-rt should accept appropriate entry point signature. Also because the only way to get boot-hart is through fdt this feature implies single-hart.

Expected entry point signature for u-boot: https://github.com/u-boot/u-boot/blob/master/lib/elf.c#L26
