### PR TITLE
riscv: re-use `mcountinhibit` `try_*` functions

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Use CSR helper macros to define `marchid` register
+- Re-use `try_*` functions in `mcountinhibit`
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/mcountinhibit.rs
+++ b/riscv/src/register/mcountinhibit.rs
@@ -41,8 +41,7 @@ set_clear_csr!(
 
 #[inline]
 pub unsafe fn set_hpm(index: usize) {
-    assert!((3..32).contains(&index));
-    _set(1 << index);
+    try_set_hpm(index).unwrap();
 }
 
 #[inline]
@@ -60,8 +59,7 @@ pub unsafe fn try_set_hpm(index: usize) -> Result<()> {
 
 #[inline]
 pub unsafe fn clear_hpm(index: usize) {
-    assert!((3..32).contains(&index));
-    _clear(1 << index);
+    try_clear_hpm(index).unwrap();
 }
 
 #[inline]


### PR DESCRIPTION
Re-uses the `try_*` functions in their panicking equivalents for a slight code-size reduction.