### PR TITLE
riscv: define marchid using CSR macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- CSR helper macro to check for platform implementation
+
+### Changed
+
+- Use CSR helper macros to define `marchid` register
+
 ## [v0.12.1] - 2024-10-20
 
 ### Changed

--- a/riscv/src/register/marchid.rs
+++ b/riscv/src/register/marchid.rs
@@ -1,28 +1,8 @@
 //! marchid register
 
-use core::num::NonZeroUsize;
-
-/// marchid register
-#[derive(Clone, Copy, Debug)]
-pub struct Marchid {
-    bits: NonZeroUsize,
-}
-
-impl Marchid {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits.get()
-    }
-}
-
-read_csr!(0xF12);
-
-/// Reads the CSR
-#[inline]
-pub fn read() -> Option<Marchid> {
-    let r = unsafe { _read() };
-    // When marchid is hardwired to zero it means that the marchid
-    // csr isn't implemented.
-    NonZeroUsize::new(r).map(|bits| Marchid { bits })
+read_only_csr! {
+    /// `marchid` register
+    Marchid: 0xF12,
+    mask: 0xffff_ffff,
+    sentinel: 0,
 }


### PR DESCRIPTION
Adds a helper macro to test if a CSR is implemented on the platform.

Uses CSR helper macros to define the `marchid` register.

Related: #229 