### PR TITLE
riscv: define mideleg using CSR macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Re-use `try_*` functions in `mcountinhibit`
 - Use CSR helper macros to define `mcause` register
 - Use CSR helper macros to define `medeleg` register
+- Use CSR helper macros to define `mideleg` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -1059,3 +1059,19 @@ macro_rules! write_only_csr_field {
         }
     };
 }
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! test_csr_field {
+    ($reg:ident, $field:ident) => {{
+        $crate::paste! {
+            assert!(!$reg.$field());
+
+            $reg.[<set_ $field>](true);
+            assert!($reg.$field());
+
+            $reg.[<set_ $field>](false);
+            assert!(!$reg.$field());
+        }
+    }};
+}

--- a/riscv/src/register/medeleg.rs
+++ b/riscv/src/register/medeleg.rs
@@ -131,36 +131,22 @@ set_clear_csr!(
 mod tests {
     use super::*;
 
-    macro_rules! test_field {
-        ($reg:ident, $field:ident) => {{
-            $crate::paste! {
-                assert!(!$reg.$field());
-
-                $reg.[<set_ $field>](true);
-                assert!($reg.$field());
-
-                $reg.[<set_ $field>](false);
-                assert!(!$reg.$field());
-            }
-        }};
-    }
-
     #[test]
     fn test_medeleg() {
         let mut m = Medeleg::from_bits(0);
 
-        test_field!(m, instruction_misaligned);
-        test_field!(m, instruction_fault);
-        test_field!(m, illegal_instruction);
-        test_field!(m, breakpoint);
-        test_field!(m, load_misaligned);
-        test_field!(m, load_fault);
-        test_field!(m, store_misaligned);
-        test_field!(m, store_fault);
-        test_field!(m, user_env_call);
-        test_field!(m, supervisor_env_call);
-        test_field!(m, instruction_page_fault);
-        test_field!(m, load_page_fault);
-        test_field!(m, store_page_fault);
+        test_csr_field!(m, instruction_misaligned);
+        test_csr_field!(m, instruction_fault);
+        test_csr_field!(m, illegal_instruction);
+        test_csr_field!(m, breakpoint);
+        test_csr_field!(m, load_misaligned);
+        test_csr_field!(m, load_fault);
+        test_csr_field!(m, store_misaligned);
+        test_csr_field!(m, store_fault);
+        test_csr_field!(m, user_env_call);
+        test_csr_field!(m, supervisor_env_call);
+        test_csr_field!(m, instruction_page_fault);
+        test_csr_field!(m, load_page_fault);
+        test_csr_field!(m, store_page_fault);
     }
 }

--- a/riscv/src/register/mideleg.rs
+++ b/riscv/src/register/mideleg.rs
@@ -1,38 +1,29 @@
 //! mideleg register
 
-/// mideleg register
-#[derive(Clone, Copy, Debug)]
-pub struct Mideleg {
-    bits: usize,
+read_write_csr! {
+    /// `mideleg` register
+    Mideleg: 0x303,
+    mask: 0x222,
 }
 
-impl Mideleg {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
+read_write_csr_field! {
+    Mideleg,
     /// Supervisor Software Interrupt Delegate
-    #[inline]
-    pub fn ssoft(&self) -> bool {
-        self.bits & (1 << 1) != 0
-    }
-
-    /// Supervisor Timer Interrupt Delegate
-    #[inline]
-    pub fn stimer(&self) -> bool {
-        self.bits & (1 << 5) != 0
-    }
-
-    /// Supervisor External Interrupt Delegate
-    #[inline]
-    pub fn sext(&self) -> bool {
-        self.bits & (1 << 9) != 0
-    }
+    ssoft: 1,
 }
 
-read_csr_as!(Mideleg, 0x303);
+read_write_csr_field! {
+    Mideleg,
+    /// Supervisor Timer Interrupt Delegate
+    stimer: 5,
+}
+
+read_write_csr_field! {
+    Mideleg,
+    /// Supervisor External Interrupt Delegate
+    sext: 9,
+}
+
 set!(0x303);
 clear!(0x303);
 

--- a/riscv/src/register/mideleg.rs
+++ b/riscv/src/register/mideleg.rs
@@ -36,3 +36,17 @@ set_clear_csr!(
 set_clear_csr!(
     /// Supervisor External Interrupt Delegate
     , set_sext, clear_sext, 1 << 9);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mideleg() {
+        let mut m = Mideleg::from_bits(0);
+
+        test_csr_field!(m, ssoft);
+        test_csr_field!(m, stimer);
+        test_csr_field!(m, sext);
+    }
+}


### PR DESCRIPTION
Uses CSR helper macros to define the `mideleg` register.

Adds basic unit tests for the `mideleg` register.

Related: https://github.com/rust-embedded/riscv/issues/229