### PR TITLE
riscv: define mie using CSR macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `medeleg` register
 - Use CSR helper macros to define `mideleg` register
 - Use CSR helper macros to define `mcounteren` register
+- Use CSR helper macros to define `mie` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/mie.rs
+++ b/riscv/src/register/mie.rs
@@ -63,3 +63,20 @@ set_clear_csr!(
 set_clear_csr!(
     /// Machine External Interrupt Enable
     , set_mext, clear_mext, 1 << 11);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mie() {
+        let mut m = Mie::from_bits(0);
+
+        test_csr_field!(m, ssoft);
+        test_csr_field!(m, msoft);
+        test_csr_field!(m, stimer);
+        test_csr_field!(m, mtimer);
+        test_csr_field!(m, sext);
+        test_csr_field!(m, mext);
+    }
+}

--- a/riscv/src/register/mie.rs
+++ b/riscv/src/register/mie.rs
@@ -1,56 +1,47 @@
 //! mie register
 
-/// mie register
-#[derive(Clone, Copy, Debug)]
-pub struct Mie {
-    bits: usize,
+read_write_csr! {
+    /// `mie` register
+    Mie: 0x304,
+    mask: 0xaaa,
 }
 
-impl Mie {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
+read_write_csr_field! {
+    Mie,
     /// Supervisor Software Interrupt Enable
-    #[inline]
-    pub fn ssoft(&self) -> bool {
-        self.bits & (1 << 1) != 0
-    }
-
-    /// Machine Software Interrupt Enable
-    #[inline]
-    pub fn msoft(&self) -> bool {
-        self.bits & (1 << 3) != 0
-    }
-
-    /// Supervisor Timer Interrupt Enable
-    #[inline]
-    pub fn stimer(&self) -> bool {
-        self.bits & (1 << 5) != 0
-    }
-
-    /// Machine Timer Interrupt Enable
-    #[inline]
-    pub fn mtimer(&self) -> bool {
-        self.bits & (1 << 7) != 0
-    }
-
-    /// Supervisor External Interrupt Enable
-    #[inline]
-    pub fn sext(&self) -> bool {
-        self.bits & (1 << 9) != 0
-    }
-
-    /// Machine External Interrupt Enable
-    #[inline]
-    pub fn mext(&self) -> bool {
-        self.bits & (1 << 11) != 0
-    }
+    ssoft: 1,
 }
 
-read_csr_as!(Mie, 0x304);
+read_write_csr_field! {
+    Mie,
+    /// Machine Software Interrupt Enable
+    msoft: 3,
+}
+
+read_write_csr_field! {
+    Mie,
+    /// Supervisor Timer Interrupt Enable
+    stimer: 5,
+}
+
+read_write_csr_field! {
+    Mie,
+    /// Machine Timer Interrupt Enable
+    mtimer: 7,
+}
+
+read_write_csr_field! {
+    Mie,
+    /// Supervisor External Interrupt Enable
+    sext: 9,
+}
+
+read_write_csr_field! {
+    Mie,
+    /// Machine External Interrupt Enable
+    mext: 11,
+}
+
 set!(0x304);
 clear!(0x304);
 


### PR DESCRIPTION
Uses CSR helper macros to define the `mie` register.

Adds basic unit tests for the `mie` register.