### PR TITLE
riscv: define mimpid using CSR macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mideleg` register
 - Use CSR helper macros to define `mcounteren` register
 - Use CSR helper macros to define `mie` register
+- Use CSR helper macros to define `mimpid` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/mimpid.rs
+++ b/riscv/src/register/mimpid.rs
@@ -1,28 +1,8 @@
 //! mimpid register
 
-use core::num::NonZeroUsize;
-
-/// mimpid register
-#[derive(Clone, Copy, Debug)]
-pub struct Mimpid {
-    bits: NonZeroUsize,
-}
-
-impl Mimpid {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits.get()
-    }
-}
-
-read_csr!(0xF13);
-
-/// Reads the CSR
-#[inline]
-pub fn read() -> Option<Mimpid> {
-    let r = unsafe { _read() };
-    // When mimpid is hardwired to zero it means that the mimpid
-    // csr isn't implemented.
-    NonZeroUsize::new(r).map(|bits| Mimpid { bits })
+read_only_csr! {
+    /// `mimpid` register
+    Mimpid: 0xF13,
+    mask: 0xffff_ffff,
+    sentinel: 0,
 }


### PR DESCRIPTION
Uses CSR helper macros to define the `mimpid` register.

Related: #229 