### PR TITLE
riscv: define mip using CSR macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mie` register
 - Use CSR helper macros to define `mimpid` register
 - Use CSR helper macros to define `misa` register
+- Use CSR helper macros to define `mip` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/mip.rs
+++ b/riscv/src/register/mip.rs
@@ -54,3 +54,25 @@ set_clear_csr!(
 set_clear_csr!(
     /// Supervisor External Interrupt Pending
     , set_sext, clear_sext, 1 << 9);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mip() {
+        let mut m = Mip::from_bits(0);
+
+        test_csr_field!(m, ssoft);
+        test_csr_field!(m, stimer);
+        test_csr_field!(m, sext);
+
+        assert!(!m.msoft());
+        assert!(!m.mtimer());
+        assert!(!m.mext());
+
+        assert!(Mip::from_bits(1 << 3).msoft());
+        assert!(Mip::from_bits(1 << 7).mtimer());
+        assert!(Mip::from_bits(1 << 11).mext());
+    }
+}

--- a/riscv/src/register/mip.rs
+++ b/riscv/src/register/mip.rs
@@ -1,56 +1,47 @@
 //! mip register
 
-/// mip register
-#[derive(Clone, Copy, Debug)]
-pub struct Mip {
-    bits: usize,
+read_write_csr! {
+    /// `mip` register
+    Mip: 0x344,
+    mask: 0xaaa,
 }
 
-impl Mip {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
+read_write_csr_field! {
+    Mip,
     /// Supervisor Software Interrupt Pending
-    #[inline]
-    pub fn ssoft(&self) -> bool {
-        self.bits & (1 << 1) != 0
-    }
-
-    /// Machine Software Interrupt Pending
-    #[inline]
-    pub fn msoft(&self) -> bool {
-        self.bits & (1 << 3) != 0
-    }
-
-    /// Supervisor Timer Interrupt Pending
-    #[inline]
-    pub fn stimer(&self) -> bool {
-        self.bits & (1 << 5) != 0
-    }
-
-    /// Machine Timer Interrupt Pending
-    #[inline]
-    pub fn mtimer(&self) -> bool {
-        self.bits & (1 << 7) != 0
-    }
-
-    /// Supervisor External Interrupt Pending
-    #[inline]
-    pub fn sext(&self) -> bool {
-        self.bits & (1 << 9) != 0
-    }
-
-    /// Machine External Interrupt Pending
-    #[inline]
-    pub fn mext(&self) -> bool {
-        self.bits & (1 << 11) != 0
-    }
+    ssoft: 1,
 }
 
-read_csr_as!(Mip, 0x344);
+read_only_csr_field! {
+    Mip,
+    /// Machine Software Interrupt Pending
+    msoft: 3,
+}
+
+read_write_csr_field! {
+    Mip,
+    /// Supervisor Timer Interrupt Pending
+    stimer: 5,
+}
+
+read_only_csr_field! {
+    Mip,
+    /// Machine Timer Interrupt Pending
+    mtimer: 7,
+}
+
+read_write_csr_field! {
+    Mip,
+    /// Supervisor External Interrupt Pending
+    sext: 9,
+}
+
+read_only_csr_field! {
+    Mip,
+    /// Machine External Interrupt Pending
+    mext: 11,
+}
+
 set!(0x344);
 clear!(0x344);
 


### PR DESCRIPTION
Uses CSR helper macros to define the `mip` register.

Adds basic unit tests for the `mip` register.

Related: https://github.com/rust-embedded/riscv/issues/229