### PR TITLE
riscv: define misa using CSR macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mcounteren` register
 - Use CSR helper macros to define `mie` register
 - Use CSR helper macros to define `mimpid` register
+- Use CSR helper macros to define `misa` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -668,7 +668,6 @@ macro_rules! csr {
 macro_rules! csr_field_enum {
     ($(#[$field_ty_doc:meta])*
      $field_ty:ident {
-         range: [$field_start:literal : $field_end:literal],
          default: $default_variant:ident,
          $($variant:ident = $value:expr$(,)?)+
      }$(,)?

--- a/riscv/src/register/misa.rs
+++ b/riscv/src/register/misa.rs
@@ -1,58 +1,59 @@
 //! misa register
 
-use core::num::NonZeroUsize;
-
-/// misa register
-#[derive(Clone, Copy, Debug)]
-pub struct Misa {
-    bits: NonZeroUsize,
+#[cfg(target_arch = "riscv32")]
+read_only_csr! {
+    /// `misa` register
+    Misa: 0x301,
+    mask: 0xc3ff_ffff,
+    sentinel: 0,
 }
 
-/// Base integer ISA width
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum XLEN {
-    XLEN32 = 1,
-    XLEN64 = 2,
-    XLEN128 = 3,
+#[cfg(not(target_arch = "riscv32"))]
+read_only_csr! {
+    /// `misa` register
+    Misa: 0x301,
+    mask: 0xc000_0000_03ff_ffff,
+    sentinel: 0,
 }
 
-impl XLEN {
-    /// Converts a number into an ISA width
-    pub(crate) fn from(value: u8) -> Self {
-        match value {
-            1 => XLEN::XLEN32,
-            2 => XLEN::XLEN64,
-            3 => XLEN::XLEN128,
-            _ => unreachable!(),
-        }
+csr_field_enum! {
+    /// Base integer ISA width
+    XLEN {
+        default: XLEN32,
+        XLEN32 = 1,
+        XLEN64 = 2,
+        XLEN128 = 3,
     }
+}
+
+#[cfg(target_arch = "riscv32")]
+read_only_csr_field! {
+    Misa,
+    /// Effective xlen in M-mode (i.e., `MXLEN`).
+    mxl,
+    XLEN: [30:31],
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+read_only_csr_field! {
+    Misa,
+    /// Effective xlen in M-mode (i.e., `MXLEN`).
+    mxl,
+    XLEN: [62:63],
 }
 
 impl Misa {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits.get()
-    }
-
-    /// Effective xlen in M-mode (i.e., `MXLEN`).
-    #[inline]
-    pub fn mxl(&self) -> XLEN {
-        let value = (self.bits() >> (usize::BITS - 2)) as u8;
-        XLEN::from(value)
-    }
-
     /// Returns true when a given extension is implemented.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// let misa = unsafe { riscv::register::misa::read() }.unwrap();
+    /// let misa = unsafe { riscv::register::misa::try_read() }.unwrap();
     /// assert!(misa.has_extension('A')); // panics if atomic extension is not implemented
     /// ```
     #[inline]
     pub fn has_extension(&self, extension: char) -> bool {
-        let bit = extension as u8 - 65;
+        let bit = ext_char_to_bit(extension);
         if bit > 25 {
             return false;
         }
@@ -60,13 +61,7 @@ impl Misa {
     }
 }
 
-read_csr!(0x301);
-
-/// Reads the CSR
 #[inline]
-pub fn read() -> Option<Misa> {
-    let r = unsafe { _read() };
-    // When misa is hardwired to zero it means that the misa csr
-    // isn't implemented.
-    NonZeroUsize::new(r).map(|bits| Misa { bits })
+const fn ext_char_to_bit(extension: char) -> u8 {
+    (extension as u8).saturating_sub(b'A')
 }

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -406,7 +406,7 @@ impl Mstatus {
             #[cfg(riscv32)]
             () => XLEN::XLEN32,
             #[cfg(not(riscv32))]
-            () => XLEN::from(bf_extract(self.bits, 32, 2) as u8),
+            () => XLEN::try_from(bf_extract(self.bits, 32, 2)).unwrap_or_default(),
         }
     }
 
@@ -431,7 +431,7 @@ impl Mstatus {
             #[cfg(riscv32)]
             () => XLEN::XLEN32,
             #[cfg(not(riscv32))]
-            () => XLEN::from(bf_extract(self.bits, 34, 2) as u8),
+            () => XLEN::try_from(bf_extract(self.bits, 34, 2)).unwrap_or_default(),
         }
     }
 

--- a/riscv/src/register/sstatus.rs
+++ b/riscv/src/register/sstatus.rs
@@ -86,7 +86,7 @@ impl Sstatus {
             #[cfg(riscv32)]
             () => XLEN::XLEN32,
             #[cfg(not(riscv32))]
-            () => XLEN::from((self.bits >> 32) as u8 & 0x3),
+            () => XLEN::try_from((self.bits >> 32) & 0x3).unwrap_or_default(),
         }
     }
 

--- a/riscv/src/register/tests/read_only_csr.rs
+++ b/riscv/src/register/tests/read_only_csr.rs
@@ -27,7 +27,6 @@ read_only_csr_field! {
 csr_field_enum! {
     /// field enum type with valid field variants
     MtestFieldEnum {
-        range: [8:11],
         default: Field1,
         Field1 = 1,
         Field2 = 2,

--- a/riscv/src/register/tests/read_write_csr.rs
+++ b/riscv/src/register/tests/read_write_csr.rs
@@ -27,7 +27,6 @@ read_write_csr_field! {
 csr_field_enum! {
     /// field enum type with valid field variants
     MtestFieldEnum {
-        range: [8:11],
         default: Field1,
         Field1 = 1,
         Field2 = 2,

--- a/riscv/src/register/tests/write_only_csr.rs
+++ b/riscv/src/register/tests/write_only_csr.rs
@@ -27,7 +27,6 @@ write_only_csr_field! {
 csr_field_enum! {
     /// field enum type with valid field variants
     MtestFieldEnum {
-        range: [8:11],
         default: Field1,
         Field1 = 1,
         Field2 = 2,


### PR DESCRIPTION
Removes the unused field range arguments from the CSR field enum helper macro.

Uses CSR helper macros to define the `misa` register.

Corrections for other users of the `XLEN` enum.

Adds basic unit tests for the `misa` register.

Related: #229