### PR TITLE
riscv: define mstatus using CSR macro

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mimpid` register
 - Use CSR helper macros to define `misa` register
 - Use CSR helper macros to define `mip` register
+- Use CSR helper macros to define `mstatus` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -34,6 +34,7 @@
 
 #![no_std]
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::eq_op)]
 
 pub use paste::paste;
 

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -1104,4 +1104,13 @@ macro_rules! test_csr_field {
             assert_eq!($reg.[<try_set_ $field>]($index, false), Err($err));
         }
     }};
+
+    // test an enum bit field
+    ($reg:ident, $field:ident: $var:expr) => {{
+        $crate::paste! {
+            $reg.[<set_ $field>]($var);
+            assert_eq!($reg.$field(), $var);
+            assert_eq!($reg.[<try_ $field>](), Ok($var));
+        }
+    }};
 }

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -669,14 +669,20 @@ macro_rules! csr_field_enum {
     ($(#[$field_ty_doc:meta])*
      $field_ty:ident {
          default: $default_variant:ident,
-         $($variant:ident = $value:expr$(,)?)+
+         $(
+             $(#[$field_doc:meta])*
+             $variant:ident = $value:expr$(,)?
+          )+
      }$(,)?
     ) => {
          $(#[$field_ty_doc])*
          #[repr(usize)]
          #[derive(Clone, Copy, Debug, Eq, PartialEq)]
          pub enum $field_ty {
-             $($variant = $value),+
+             $(
+                 $(#[$field_doc])*
+                 $variant = $value
+             ),+
          }
 
          impl $field_ty {

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -531,13 +531,42 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_mpp() {
+    fn test_mstatus() {
         let mut mstatus = Mstatus { bits: 0 };
-        mstatus.set_mpp(MPP::User);
-        assert_eq!(mstatus.mpp(), MPP::User);
-        mstatus.set_mpp(MPP::Machine);
-        assert_eq!(mstatus.mpp(), MPP::Machine);
-        mstatus.set_mpp(MPP::Supervisor);
-        assert_eq!(mstatus.mpp(), MPP::Supervisor);
+
+        test_csr_field!(mstatus, mpp: MPP::User);
+        test_csr_field!(mstatus, mpp: MPP::Machine);
+        test_csr_field!(mstatus, mpp: MPP::Supervisor);
+
+        test_csr_field!(mstatus, spp: SPP::User);
+        test_csr_field!(mstatus, spp: SPP::Supervisor);
+
+        test_csr_field!(mstatus, fs: FS::Off);
+        test_csr_field!(mstatus, fs: FS::Initial);
+        test_csr_field!(mstatus, fs: FS::Clean);
+        test_csr_field!(mstatus, fs: FS::Dirty);
+
+        test_csr_field!(mstatus, vs: VS::Off);
+        test_csr_field!(mstatus, vs: VS::Initial);
+        test_csr_field!(mstatus, vs: VS::Clean);
+        test_csr_field!(mstatus, vs: VS::Dirty);
+
+        test_csr_field!(mstatus, xs: XS::AllOff);
+        test_csr_field!(mstatus, xs: XS::NoneDirtyOrClean);
+        test_csr_field!(mstatus, xs: XS::NoneDirtySomeClean);
+        test_csr_field!(mstatus, xs: XS::SomeDirty);
+
+        test_csr_field!(mstatus, sie);
+        test_csr_field!(mstatus, mie);
+        test_csr_field!(mstatus, spie);
+        test_csr_field!(mstatus, ube);
+        test_csr_field!(mstatus, mpie);
+        test_csr_field!(mstatus, mprv);
+        test_csr_field!(mstatus, sum);
+        test_csr_field!(mstatus, mxr);
+        test_csr_field!(mstatus, tvm);
+        test_csr_field!(mstatus, tw);
+        test_csr_field!(mstatus, tsr);
+        test_csr_field!(mstatus, sd);
     }
 }

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -3,9 +3,6 @@
 pub use super::misa::XLEN;
 #[cfg(not(target_arch = "riscv32"))]
 use crate::bits::{bf_extract, bf_insert};
-#[cfg(target_arch = "riscv32")]
-use crate::result::Error;
-use crate::result::Result;
 
 #[cfg(not(target_arch = "riscv32"))]
 read_write_csr! {
@@ -253,28 +250,13 @@ impl Mstatus {
     /// Note this updates a previously read [`Mstatus`] value, but does not
     /// affect the mstatus CSR itself.
     ///
-    /// **NOTE**: panics on RISCV-32 platforms.
-    #[inline]
-    pub fn set_uxl(&mut self, uxl: XLEN) {
-        self.try_set_uxl(uxl).unwrap();
-    }
-
-    /// Attempts to update Effective xlen in U-mode (i.e., `UXLEN`).
+    /// # Note
     ///
-    /// Note this updates a previously read [`Mstatus`] value, but does not
-    /// affect the mstatus CSR itself.
+    /// In RISCV-32, `UXL` does not exist, and `UXLEN` is always [`XLEN::XLEN32`].
     #[inline]
-    #[cfg_attr(not(target_arch = "riscv64"), allow(unused_variables))]
-    pub fn try_set_uxl(&mut self, uxl: XLEN) -> Result<()> {
-        match () {
-            #[cfg(not(target_arch = "riscv32"))]
-            () => {
-                self.bits = bf_insert(self.bits, 32, 2, uxl as usize);
-                Ok(())
-            }
-            #[cfg(target_arch = "riscv32")]
-            () => Err(Error::Unimplemented),
-        }
+    #[cfg(not(target_arch = "riscv32"))]
+    pub fn set_uxl(&mut self, uxl: XLEN) {
+        self.bits = bf_insert(self.bits, 32, 2, uxl as usize);
     }
 
     /// Effective xlen in S-mode (i.e., `SXLEN`).
@@ -295,28 +277,13 @@ impl Mstatus {
     /// Note this updates a previously read [`Mstatus`] value, but does not
     /// affect the mstatus CSR itself.
     ///
-    /// **NOTE**: panics on RISCV-32 platforms.
-    #[inline]
-    pub fn set_sxl(&mut self, sxl: XLEN) {
-        self.try_set_sxl(sxl).unwrap();
-    }
-
-    /// Attempts to update Effective xlen in S-mode (i.e., `SXLEN`).
+    /// # Note
     ///
-    /// Note this updates a previously read [`Mstatus`] value, but does not
-    /// affect the mstatus CSR itself.
+    /// In RISCV-32, `SXL` does not exist, and `SXLEN` is always [`XLEN::XLEN32`].
     #[inline]
-    #[cfg_attr(not(target_arch = "riscv64"), allow(unused_variables))]
-    pub fn try_set_sxl(&mut self, sxl: XLEN) -> Result<()> {
-        match () {
-            #[cfg(not(target_arch = "riscv32"))]
-            () => {
-                self.bits = bf_insert(self.bits, 34, 2, sxl as usize);
-                Ok(())
-            }
-            #[cfg(target_arch = "riscv32")]
-            () => Err(Error::Unimplemented),
-        }
+    #[cfg(not(target_arch = "riscv32"))]
+    pub fn set_sxl(&mut self, sxl: XLEN) {
+        self.bits = bf_insert(self.bits, 34, 2, sxl as usize);
     }
 
     /// S-mode non-instruction-fetch memory endianness.

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -1,6 +1,7 @@
 //! mstatus register
 
 pub use super::misa::XLEN;
+#[cfg(not(target_arch = "riscv32"))]
 use crate::bits::{bf_extract, bf_insert};
 #[cfg(target_arch = "riscv32")]
 use crate::result::Error;
@@ -336,29 +337,15 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_sbe`] to directly update the
     /// CSR.
     ///
-    /// **NOTE**: panics on RISCV-32 platforms.
-    #[inline]
-    pub fn set_sbe(&mut self, endianness: Endianness) {
-        self.try_set_sbe(endianness).unwrap();
-    }
-
-    /// Update S-mode non-instruction-fetch memory endianness
+    /// # Note
     ///
-    /// Note this updates a previously read [`Mstatus`] value, but does not
-    /// affect the mstatus CSR itself. See [`set_sbe`] to directly update the
-    /// CSR.
+    /// On RISCV-32 platforms, this function does not exist on the [`Mstatus`] instance.
+    ///
+    /// Instead, RISCV-32 users should use the [`Mstatush`](crate::register::mstatush::Mstatush) register.
     #[inline]
-    #[cfg_attr(not(target_arch = "riscv64"), allow(unused_variables))]
-    pub fn try_set_sbe(&mut self, endianness: Endianness) -> Result<()> {
-        match () {
-            #[cfg(not(target_arch = "riscv32"))]
-            () => {
-                self.bits = bf_insert(self.bits, 36, 1, endianness as usize);
-                Ok(())
-            }
-            #[cfg(target_arch = "riscv32")]
-            () => Err(Error::Unimplemented),
-        }
+    #[cfg(not(target_arch = "riscv32"))]
+    pub fn set_sbe(&mut self, endianness: Endianness) {
+        self.bits = bf_insert(self.bits, 36, 1, endianness as usize);
     }
 
     /// M-mode non-instruction-fetch memory endianness
@@ -379,29 +366,15 @@ impl Mstatus {
     /// affect the mstatus CSR itself. See [`set_mbe`] to directly update the
     /// CSR.
     ///
-    /// **NOTE**: panics on RISCV-32 platforms.
-    #[inline]
-    pub fn set_mbe(&mut self, endianness: Endianness) {
-        self.try_set_mbe(endianness).unwrap();
-    }
-
-    /// Update M-mode non-instruction-fetch memory endianness
+    /// # Note
     ///
-    /// Note this updates a previously read [`Mstatus`] value, but does not
-    /// affect the mstatus CSR itself. See [`set_mbe`] to directly update the
-    /// CSR.
+    /// On RISCV-32 platforms, this function does not exist on the [`Mstatus`] instance.
+    ///
+    /// Instead, RISCV-32 users should use the [`Mstatush`](crate::register::mstatush::Mstatush) register.
     #[inline]
-    #[cfg_attr(not(target_arch = "riscv64"), allow(unused_variables))]
-    pub fn try_set_mbe(&mut self, endianness: Endianness) -> Result<()> {
-        match () {
-            #[cfg(not(target_arch = "riscv32"))]
-            () => {
-                self.bits = bf_insert(self.bits, 37, 1, endianness as usize);
-                Ok(())
-            }
-            #[cfg(target_arch = "riscv32")]
-            () => Err(Error::Unimplemented),
-        }
+    #[cfg(not(target_arch = "riscv32"))]
+    pub fn set_mbe(&mut self, endianness: Endianness) {
+        self.bits = bf_insert(self.bits, 37, 1, endianness as usize);
     }
 }
 


### PR DESCRIPTION
Adds an optional field documentation macro argument to allow adding documentation to CSR field enum variants.

Current macros for CSR field enum accessors allow for the MSB and LSB to hold the same value (for single-bit enum fields).

Clippy defaults to `deny(clippy::eq_op)`. The simplest solution is to allow the lint. A more robust solution is to special-case equal operands with new macro arm.

Uses CSR macro helpers to define the `mstatus` CSR register.

Adds a CSR test field macro arm for enum fields.

Adds more unit test cases for `Mstatus` field accessors.
