### PR TITLE
riscv: define `mstatush` CSR with macro helpers

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `misa` register
 - Use CSR helper macros to define `mip` register
 - Use CSR helper macros to define `mstatus` register
+- Use CSR helper macros to define `mstatush` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/mstatush.rs
+++ b/riscv/src/register/mstatush.rs
@@ -42,3 +42,20 @@ pub unsafe fn set_mbe(endianness: Endianness) {
         Endianness::LittleEndian => _clear(1 << 5),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mstatush() {
+        let mut m = Mstatush::from_bits(0);
+
+        [Endianness::LittleEndian, Endianness::BigEndian]
+            .into_iter()
+            .for_each(|endianness| {
+                test_csr_field!(m, sbe: endianness);
+                test_csr_field!(m, mbe: endianness);
+            });
+    }
+}

--- a/riscv/src/register/mstatush.rs
+++ b/riscv/src/register/mstatush.rs
@@ -2,28 +2,26 @@
 
 pub use super::mstatus::Endianness;
 
-/// mstatus register
-#[derive(Clone, Copy, Debug)]
-pub struct Mstatush {
-    bits: usize,
+read_write_csr! {
+    /// mstatus register
+    Mstatush: 0x310,
+    mask: 0x30,
 }
 
-impl Mstatush {
+read_write_csr_field! {
+    Mstatush,
     /// S-mode non-instruction-fetch memory endianness
-    #[inline]
-    pub fn sbe(&self) -> Endianness {
-        Endianness::from(self.bits & (1 << 4) != 0)
-    }
-
-    /// M-mode non-instruction-fetch memory endianness
-    #[inline]
-    pub fn mbe(&self) -> Endianness {
-        Endianness::from(self.bits & (1 << 5) != 0)
-    }
+    sbe,
+    Endianness: [4:4],
 }
 
-read_csr_as_rv32!(Mstatush, 0x310);
-write_csr_rv32!(0x310);
+read_write_csr_field! {
+    Mstatush,
+    /// M-mode non-instruction-fetch memory endianness
+    mbe,
+    Endianness: [5:5],
+}
+
 set_rv32!(0x310);
 clear_rv32!(0x310);
 


### PR DESCRIPTION
Uses CSR macro helpers to define the `mstatush` CSR register.

Adds a basic unit-tests for the `mstatush` CSR.