### PR TITLE
Simplify register macros

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Simplify register macros with `cfg` field
 - Align assembly functions with `cortex-m`
 - Use CSR helper macros to define `marchid` register
 - Re-use `try_*` functions in `mcountinhibit`


### PR DESCRIPTION
I added a `cfg` field and some recursive macro calls to reduce duplicates in register macros.