### PR TITLE
riscv: define mtvec CSR with macro helpers

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mip` register
 - Use CSR helper macros to define `mstatus` register
 - Use CSR helper macros to define `mstatush` register
+- Use CSR helper macros to define `mtvec` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -35,6 +35,7 @@
 #![no_std]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::eq_op)]
+#![allow(clippy::identity_op)]
 
 pub use paste::paste;
 

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -498,7 +498,7 @@ macro_rules! clear_pmp {
 macro_rules! csr {
     ($(#[$doc:meta])*
      $ty:ident,
-     $mask:literal) => {
+     $mask:expr) => {
         #[repr(C)]
         $(#[$doc])*
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/riscv/src/register/mtvec.rs
+++ b/riscv/src/register/mtvec.rs
@@ -1,50 +1,44 @@
 //! mtvec register
 
-/// mtvec register
-#[derive(Clone, Copy, Debug)]
-pub struct Mtvec {
-    bits: usize,
+const MASK: usize = usize::MAX;
+const TRAP_MASK: usize = 0b11;
+
+read_write_csr! {
+    /// mtvec register
+    Mtvec: 0x305,
+    mask: MASK,
 }
 
-/// Trap mode
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum TrapMode {
-    Direct = 0,
-    Vectored = 1,
+csr_field_enum! {
+    /// Trap mode
+    TrapMode {
+        default: Direct,
+        Direct = 0,
+        Vectored = 1,
+    }
+}
+
+read_write_csr_field! {
+    Mtvec,
+    /// Accesses the trap-vector mode..
+    trap_mode,
+    TrapMode: [0:1],
 }
 
 impl Mtvec {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
     /// Returns the trap-vector base-address
     #[inline]
-    pub fn address(&self) -> usize {
-        self.bits - (self.bits & 0b11)
+    pub const fn address(&self) -> usize {
+        self.bits - (self.bits & TRAP_MASK)
     }
 
-    /// Returns the trap-vector mode
+    /// Sets the trap-vector base-address.
+    ///
+    /// # Note
+    ///
+    /// The address is aligned to 4-bytes.
     #[inline]
-    pub fn trap_mode(&self) -> Option<TrapMode> {
-        let mode = self.bits & 0b11;
-        match mode {
-            0 => Some(TrapMode::Direct),
-            1 => Some(TrapMode::Vectored),
-            _ => None,
-        }
+    pub fn set_address(&mut self, address: usize) {
+        self.bits = (address & !TRAP_MASK) | (self.bits & TRAP_MASK);
     }
-}
-
-read_csr_as!(Mtvec, 0x305);
-
-write_csr!(0x305);
-
-/// Writes the CSR
-#[inline]
-pub unsafe fn write(addr: usize, mode: TrapMode) {
-    let bits = addr + mode as usize;
-    _write(bits);
 }

--- a/riscv/src/register/mtvec.rs
+++ b/riscv/src/register/mtvec.rs
@@ -42,3 +42,23 @@ impl Mtvec {
         self.bits = (address & !TRAP_MASK) | (self.bits & TRAP_MASK);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mtvec() {
+        let mut m = Mtvec::from_bits(0);
+
+        (1..=usize::BITS)
+            .map(|r| (((1u128 << r) - 1) as usize))
+            .for_each(|address| {
+                m.set_address(address);
+                assert_eq!(m.address(), address & !TRAP_MASK);
+            });
+
+        test_csr_field!(m, trap_mode: TrapMode::Direct);
+        test_csr_field!(m, trap_mode: TrapMode::Vectored);
+    }
+}


### PR DESCRIPTION
Uses the CSR macro helpers to define the `mtvec` CSR register.

Adds basic unit-tests for the `mtvec` CSR.

Ignores the warning for the `clippy::identity_op` to allow using ranged bitfield CSR macro arguments with a leading `0`.

Changes the macro argument type to `expr` to allow using constants, expressions, and other initializers for CSR mask values.