### PR TITLE
Make sure .heap is 4-byte aligned

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Ensure the `.heap` section is 4-byte aligned
 - Limit rustc cfg flags to `riscvi`, `riscvm`, `riscvf`, and `riscvd`.
 - Temporary use of `RISCV_RT_LLVM_ARCH_PATCH` environment variable to include the
   temporary patch required for avoid LLVM spurious errors.

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -168,7 +168,7 @@ SECTIONS
   __ebss = .;
 
   /* fictitious region that represents the memory available for the heap */
-  .heap (NOLOAD) :
+  .heap (NOLOAD) : ALIGN(4)
   {
     __sheap = .;
     . += _heap_size;


### PR DESCRIPTION
Note sure why the `. = ALIGN(${ARCH_WIDTH});` before `__ebss = .;` doesn't also align `.heap`.

```toml
[package]
name = "foo"
version = "0.1.0"
edition = "2024"

[dependencies]
critical-section = "1.2.0"
embedded-alloc = "0.6.0"
riscv = { version = "0.12.1", features = ["critical-section-single-hart"] }

[dependencies.riscv-rt]
git = "https://github.com/rust-embedded/riscv.git"
rev = "fe6da179b437f23545a5db13ead28dc9855523a4"
```

```text
MEMORY {
  FLASH (RX) : ORIGIN = 0x20000000, LENGTH = 0x80000
  RAM    (W) : ORIGIN = 0x10000000, LENGTH = 0x20000
}

REGION_ALIAS("REGION_TEXT", FLASH);
REGION_ALIAS("REGION_RODATA", FLASH);
REGION_ALIAS("REGION_DATA", RAM);
REGION_ALIAS("REGION_BSS", RAM);
REGION_ALIAS("REGION_HEAP", RAM);
REGION_ALIAS("REGION_STACK", RAM);
_heap_size = 0x10000;
```

```rust
#![no_std]
#![no_main]

extern crate alloc;

use embedded_alloc::TlsfHeap as Heap;
use {critical_section as _, riscv as _};

#[global_allocator]
static ALLOCATOR: Heap = Heap::empty();

#[panic_handler]
fn panic(info: &core::panic::PanicInfo) -> ! {
    for &byte in alloc::format!("{info}").as_bytes() {
        unsafe { (0x40000000 as *mut u8).write_volatile(byte) };
    }
    loop {}
}

#[riscv_rt::entry]
fn main() -> ! {
    panic!()
}
```

```
% RUSTFLAGS='-C link-arg=-Tmemory.x -C link-arg=-Tlink.x' cargo build --release --target=riscv32imc-unknown-none-elf
   Compiling foo v0.1.0 (/tmp/foo)
error: linking with `rust-lld` failed: exit status: 1
  |
  = note: [...]
  = note: rust-lld: error: 
          BUG(riscv-rt): start of .heap is not 4-byte aligned
          
          rust-lld: error: 
          BUG(riscv-rt): start of .heap is not 4-byte aligned
          

error: could not compile `foo` (bin "foo") due to 1 previous error
```