### PR TITLE
riscv: define satp CSR with macro helpers

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mstatush` register
 - Use CSR helper macros to define `mtvec` register
 - Use CSR helper macros to define `mtvendorid` register
+- Use CSR helper macros to define `satp` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -601,8 +601,8 @@ macro_rules! csr_field_enum {
 #[macro_export]
 macro_rules! read_write_csr {
     ($(#[$doc:meta])+
-     $ty:ident: $csr:tt,
-     mask: $mask:tt$(,)?
+     $ty:ident: $csr:expr,
+     mask: $mask:expr$(,)?
     ) => {
         $crate::csr!($(#[$doc])+ $ty, $mask);
 
@@ -617,8 +617,8 @@ macro_rules! read_write_csr {
 #[macro_export]
 macro_rules! read_only_csr {
     ($(#[$doc:meta])+
-     $ty:ident: $csr:tt,
-     mask: $mask:tt$(,)?
+     $ty:ident: $csr:expr,
+     mask: $mask:expr$(,)?
     ) => {
         $crate::csr! { $(#[$doc])+ $ty, $mask }
 
@@ -626,8 +626,8 @@ macro_rules! read_only_csr {
     };
 
     ($(#[$doc:meta])+
-     $ty:ident: $csr:tt,
-     mask: $mask:tt,
+     $ty:ident: $csr:expr,
+     mask: $mask:expr,
      sentinel: $sentinel:tt$(,)?,
     ) => {
         $crate::csr! { $(#[$doc])+ $ty, $mask }
@@ -642,8 +642,8 @@ macro_rules! read_only_csr {
 #[macro_export]
 macro_rules! write_only_csr {
     ($(#[$doc:meta])+
-     $ty:ident: $csr:literal,
-     mask: $mask:literal$(,)?
+     $ty:ident: $csr:expr,
+     mask: $mask:expr$(,)?
     ) => {
         $crate::csr! { $(#[$doc])+ $ty, $mask }
 


### PR DESCRIPTION
Uses CSR macro helpers to define the `satp` CSR register.

Changes the CSR number + mask macro arguments into `expr` to allow for definitions using constants and type expressions.

Adds basic unit tests for the `satp` CSR.