### PR TITLE
riscv: define `scause` CSR with macro helpers

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `mtvendorid` register
 - Use CSR helper macros to define `satp` register
 - Use CSR helper macros to define `pmpcfgx` field types
+- Use CSR helper macros to define `scause` field types
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/scause.rs
+++ b/riscv/src/register/scause.rs
@@ -3,25 +3,47 @@
 pub use crate::interrupt::Trap;
 pub use riscv_pac::{CoreInterruptNumber, ExceptionNumber, InterruptNumber}; // re-export useful riscv-pac traits
 
-/// scause register
-#[derive(Clone, Copy)]
-pub struct Scause {
-    bits: usize,
+read_write_csr! {
+    /// scause register
+    Scause: 0x142,
+    mask: usize::MAX,
+}
+
+#[cfg(target_arch = "riscv32")]
+read_write_csr_field! {
+    Scause,
+    /// Returns the type of the trap:
+    ///
+    /// - `true`: an interrupt caused the trap
+    /// - `false`: an exception caused the trap
+    interrupt: 31,
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+read_write_csr_field! {
+    Scause,
+    /// Returns the type of the trap:
+    ///
+    /// - `true`: an interrupt caused the trap
+    /// - `false`: an exception caused the trap
+    interrupt: 63,
+}
+
+#[cfg(target_arch = "riscv32")]
+read_write_csr_field! {
+    Scause,
+    /// Returns the code field
+    code: [0:30],
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+read_write_csr_field! {
+    Scause,
+    /// Returns the code field
+    code: [0:62],
 }
 
 impl Scause {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
-    /// Returns the code field
-    #[inline]
-    pub fn code(&self) -> usize {
-        self.bits & !(1 << (usize::BITS as usize - 1))
-    }
-
     /// Returns the trap cause represented by this register.
     ///
     /// # Note
@@ -40,23 +62,14 @@ impl Scause {
     /// Is trap cause an interrupt.
     #[inline]
     pub fn is_interrupt(&self) -> bool {
-        self.bits & (1 << (usize::BITS as usize - 1)) != 0
+        self.interrupt()
     }
 
     /// Is trap cause an exception.
     #[inline]
     pub fn is_exception(&self) -> bool {
-        !self.is_interrupt()
+        !self.interrupt()
     }
-}
-
-read_csr_as!(Scause, 0x142);
-write_csr!(0x142);
-
-/// Writes the CSR
-#[inline]
-pub unsafe fn write(bits: usize) {
-    _write(bits)
 }
 
 /// Set supervisor cause register to corresponding cause.


### PR DESCRIPTION
Uses CSR macro helpers to define the `scause` CSR register.

Adds basic unit tests for the `scause` CSR.

Related: #229