### PR TITLE
riscv: define `sie` CSR with macro helpers 

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `satp` register
 - Use CSR helper macros to define `pmpcfgx` field types
 - Use CSR helper macros to define `scause` field types
+- Use CSR helper macros to define `sie` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/sie.rs
+++ b/riscv/src/register/sie.rs
@@ -36,3 +36,17 @@ set_clear_csr!(
 set_clear_csr!(
     /// Supervisor External Interrupt Enable
     , set_sext, clear_sext, 1 << 9);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sie() {
+        let mut sie = Sie::from_bits(0);
+
+        test_csr_field!(sie, ssoft);
+        test_csr_field!(sie, stimer);
+        test_csr_field!(sie, sext);
+    }
+}

--- a/riscv/src/register/sie.rs
+++ b/riscv/src/register/sie.rs
@@ -1,38 +1,29 @@
 //! sie register
 
+read_write_csr! {
 /// sie register
-#[derive(Clone, Copy, Debug)]
-pub struct Sie {
-    bits: usize,
+    Sie: 0x104,
+    mask: 0x222,
 }
 
-impl Sie {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
+read_write_csr_field! {
+    Sie,
     /// Supervisor Software Interrupt Enable
-    #[inline]
-    pub fn ssoft(&self) -> bool {
-        self.bits & (1 << 1) != 0
-    }
-
-    /// Supervisor Timer Interrupt Enable
-    #[inline]
-    pub fn stimer(&self) -> bool {
-        self.bits & (1 << 5) != 0
-    }
-
-    /// Supervisor External Interrupt Enable
-    #[inline]
-    pub fn sext(&self) -> bool {
-        self.bits & (1 << 9) != 0
-    }
+    ssoft: 1,
 }
 
-read_csr_as!(Sie, 0x104);
+read_write_csr_field! {
+    Sie,
+    /// Supervisor Timer Interrupt Enable
+    stimer: 5,
+}
+
+read_write_csr_field! {
+    Sie,
+    /// Supervisor Timer Interrupt Enable
+    sext: 9,
+}
+
 set!(0x104);
 clear!(0x104);
 


### PR DESCRIPTION
Uses CSR macro helpers to define the `sie` CSR register.

Adds basic unit tests for the `sie` CSR.

Related: #229