### PR TITLE
`riscv-rt` patch: remove references to `eh_frame`

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `riscv-target-parser` in build script to identify target-specific configurations.
 - Add documentation to trap frame fields.
 - Avoid using `t3`+ in startup assembly to ensure compatibility with RVE.
-- `link.x.in`: remove references to `eh_frame`.
 - Rename start/end section symbols to align with `cortex-m-rt`:
     - `_stext`: it remains, as linker files can modify it.
     - `__stext`: it coincides with `_stext`.
@@ -42,6 +41,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   allow users get the initial address of the heap when initializing an allocator.
 - Update documentation.
 - Removed `.init.rust` section, as it is no longer required.
+
+## [v0.13.1] - 2025-02-08
+
+### Changed
+
+- `link.x.in`: remove references to `eh_frame`
 
 ## [v0.13.0] - 2024-10-19
 

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.13.0"
+version = "0.13.1"
 rust-version = "1.61"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]


### PR DESCRIPTION
This PR serves to give me permission to publish a `v0.13.1` patch fr `riscv-rt`. This release cherry-picks a commit that is already in `master`, but remains still unpublished.

Note that, if accepted, I will publish the patch from the `rvrt-patch` branch, not `master`.

Closes #260