### PR TITLE
riscv: define `sip` CSR with macro helpers

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `scause` field types
 - Use CSR helper macros to define `sie` register
 - Use CSR helper macros to define `scounteren` field types
+- Use CSR helper macros to define `sip` register
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/sip.rs
+++ b/riscv/src/register/sip.rs
@@ -1,38 +1,29 @@
 //! sip register
 
-/// sip register
-#[derive(Clone, Copy, Debug)]
-pub struct Sip {
-    bits: usize,
+read_write_csr! {
+    /// sip register
+    Sip: 0x144,
+    mask: 0x222,
 }
 
-impl Sip {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
+read_write_csr_field! {
+    Sip,
     /// Supervisor Software Interrupt Pending
-    #[inline]
-    pub fn ssoft(&self) -> bool {
-        self.bits & (1 << 1) != 0
-    }
-
-    /// Supervisor Timer Interrupt Pending
-    #[inline]
-    pub fn stimer(&self) -> bool {
-        self.bits & (1 << 5) != 0
-    }
-
-    /// Supervisor External Interrupt Pending
-    #[inline]
-    pub fn sext(&self) -> bool {
-        self.bits & (1 << 9) != 0
-    }
+    ssoft: 1,
 }
 
-read_csr_as!(Sip, 0x144);
+read_only_csr_field! {
+    Sip,
+    /// Supervisor Timer Interrupt Pending
+    stimer: 5,
+}
+
+read_only_csr_field! {
+    Sip,
+    /// Supervisor External Interrupt Pending
+    sext: 9,
+}
+
 set!(0x144);
 clear!(0x144);
 

--- a/riscv/src/register/sip.rs
+++ b/riscv/src/register/sip.rs
@@ -30,3 +30,20 @@ clear!(0x144);
 set_clear_csr!(
     /// Supervisor Software Interrupt Pending
     , set_ssoft, clear_ssoft, 1 << 1);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sip() {
+        let mut sip = Sip::from_bits(0);
+
+        test_csr_field!(sip, ssoft);
+        assert!(!sip.stimer());
+        assert!(!sip.sext());
+
+        assert!(Sip::from_bits(1 << 5).stimer());
+        assert!(Sip::from_bits(1 << 9).sext());
+    }
+}


### PR DESCRIPTION
Uses CSR macro helpers to define the `sip` CSR register.

Adds basic unit tests for the `sip` CSR.

Related: https://github.com/rust-embedded/riscv/issues/229