### PR TITLE
riscv: define `stvec` CSR with macro helpers 

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `scounteren` field types
 - Use CSR helper macros to define `sip` register
 - Use CSR helper macros to define `sstatus` field types
+- Use CSR helper macros to define `stvec` field types
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/stvec.rs
+++ b/riscv/src/register/stvec.rs
@@ -1,43 +1,56 @@
 //! stvec register
 
 pub use crate::register::mtvec::TrapMode;
+use crate::result::{Error, Result};
 
-/// stvec register
-#[derive(Clone, Copy, Debug)]
-pub struct Stvec {
-    bits: usize,
+const TRAP_MASK: usize = 0b11;
+
+read_write_csr! {
+    /// stvec register
+    Stvec: 0x105,
+    mask: usize::MAX,
+}
+
+read_write_csr_field! {
+    Stvec,
+    /// Returns the trap-vector mode
+    trap_mode,
+    TrapMode: [0:1],
 }
 
 impl Stvec {
-    /// Returns the contents of the register as raw bits
-    #[inline]
-    pub fn bits(&self) -> usize {
-        self.bits
-    }
-
     /// Returns the trap-vector base-address
     #[inline]
-    pub fn address(&self) -> usize {
-        self.bits - (self.bits & 0b11)
+    pub const fn address(&self) -> usize {
+        self.bits & !TRAP_MASK
     }
 
-    /// Returns the trap-vector mode
+    /// Sets the trap-vector base-address.
+    ///
+    /// # Note
+    ///
+    /// Panics if the address is not aligned to 4-bytes.
     #[inline]
-    pub fn trap_mode(&self) -> Option<TrapMode> {
-        let mode = self.bits & 0b11;
-        match mode {
-            0 => Some(TrapMode::Direct),
-            1 => Some(TrapMode::Vectored),
-            _ => None,
+    pub fn set_address(&mut self, address: usize) {
+        self.try_set_address(address).unwrap();
+    }
+
+    /// Attempts to set the trap-vector base-address.
+    ///
+    /// # Note
+    ///
+    /// Returns an error if the address is not aligned to 4-bytes.
+    #[inline]
+    pub fn try_set_address(&mut self, address: usize) -> Result<()> {
+        // check for four-byte alignment
+        if (address & TRAP_MASK) != 0 {
+            Err(Error::InvalidFieldVariant {
+                field: "stvec::address",
+                value: address,
+            })
+        } else {
+            self.bits = address | (self.bits & TRAP_MASK);
+            Ok(())
         }
     }
-}
-
-read_csr_as!(Stvec, 0x105);
-write_csr!(0x105);
-
-/// Writes the CSR
-#[inline]
-pub unsafe fn write(addr: usize, mode: TrapMode) {
-    _write(addr + mode as usize);
 }


### PR DESCRIPTION
Uses CSR macro helpers to define the `stvec` CSR register.

Adds basic unit tests for the `stvec` CSR.

Related: #229