### PR TITLE
riscv: add more `pmpcfg` CSRs

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use CSR helper macros to define `sip` register
 - Use CSR helper macros to define `sstatus` field types
 - Use CSR helper macros to define `stvec` field types
+- Add remaining `pmpcfg` CSRs from RISC-V privileged spec
 
 ## [v0.12.1] - 2024-10-20
 

--- a/riscv/src/register/pmpcfgx.rs
+++ b/riscv/src/register/pmpcfgx.rs
@@ -157,3 +157,153 @@ pub mod pmpcfg3 {
     set_pmp!();
     clear_pmp!();
 }
+
+/// Physical memory protection configuration
+/// pmpcfg4 struct contains pmp16cfg - pmp19cfg for RV32, or pmp16cfg - pmp23cfg for RV64
+pub mod pmpcfg4 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3A4);
+    write_csr_as_usize!(0x3A4);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg5 struct contains pmp20cfg - pmp23cfg for RV32 only
+#[cfg(riscv32)]
+pub mod pmpcfg5 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3A5);
+    write_csr_as_usize_rv32!(0x3A5);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg6 struct contains pmp24cfg - pmp27cfg for RV32, or pmp24cfg - pmp31cfg for RV64
+pub mod pmpcfg6 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3A6);
+    write_csr_as_usize!(0x3A6);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg7 struct contains pmp28cfg - pmp31cfg for RV32 only
+#[cfg(riscv32)]
+pub mod pmpcfg7 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3A7);
+    write_csr_as_usize_rv32!(0x3A7);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg8 struct contains pmp32cfg - pmp35cfg for RV32, or pmp32cfg - pmp39cfg for RV64
+pub mod pmpcfg8 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3A8);
+    write_csr_as_usize!(0x3A8);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg9 struct contains pmp36cfg - pmp39cfg for RV32 only
+#[cfg(riscv32)]
+pub mod pmpcfg9 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3A9);
+    write_csr_as_usize_rv32!(0x3A9);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg10 struct contains pmp40cfg - pmp43cfg for RV32, or pmp40cfg - pmp47cfg for RV64
+pub mod pmpcfg10 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3AA);
+    write_csr_as_usize!(0x3AA);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg11 struct contains pmp44cfg - pmp47cfg for RV32 only
+#[cfg(riscv32)]
+pub mod pmpcfg11 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3AB);
+    write_csr_as_usize_rv32!(0x3AB);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg12 struct contains pmp48cfg - pmp51cfg for RV32, or pmp48cfg - pmp55cfg for RV64
+pub mod pmpcfg12 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3AC);
+    write_csr_as_usize!(0x3AC);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg13 struct contains pmp52cfg - pmp55cfg for RV32 only
+#[cfg(riscv32)]
+pub mod pmpcfg13 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3AD);
+    write_csr_as_usize_rv32!(0x3AD);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg14 struct contains pmp56cfg - pmp59cfg for RV32, or pmp56cfg - pmp63cfg for RV64
+pub mod pmpcfg14 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3AE);
+    write_csr_as_usize!(0x3AE);
+
+    set_pmp!();
+    clear_pmp!();
+}
+
+/// Physical memory protection configuration
+/// pmpcfg15 struct contains pmp60cfg - pmp63cfg for RV32 only
+#[cfg(riscv32)]
+pub mod pmpcfg15 {
+    use super::{Permission, Pmpcsr, Range};
+
+    read_csr_as!(Pmpcsr, 0x3AF);
+    write_csr_as_usize_rv32!(0x3AF);
+
+    set_pmp!();
+    clear_pmp!();
+}


### PR DESCRIPTION
Adds the remaining `pmpcfg` CSRs from the RISC-V privileged specification.

From discussion with @romancardenas: https://github.com/rust-embedded/riscv/pull/257#pullrequestreview-2571862955