### PR TITLE
riscv: make mcycle & minstret writable

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- CSR helper macro `write_composite_csr` for writing 64-bit CSRs on 32-bit targets.
+- Write utilities for `mcycle`, `minstret`
+
 ## [v0.13.0] - 2025-02-18
 
 ### Added

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -449,6 +449,30 @@ macro_rules! read_composite_csr {
     };
 }
 
+/// Convenience macro to write a composite value to a CSR register.
+///
+/// - `RV32`: writes 32-bits into `hi` and 32-bits into `lo` to create a 64-bit value
+/// - `RV64`: writes a 64-bit value into `lo`
+#[macro_export]
+macro_rules! write_composite_csr {
+    ($hi:expr, $lo:expr) => {
+        /// Writes the CSR as a 64-bit value
+        #[inline]
+        pub unsafe fn write64(bits: u64) {
+            match () {
+                #[cfg(target_arch = "riscv32")]
+                () => {
+                    $hi((bits >> 32) as usize);
+                    $lo(bits as usize);
+                }
+
+                #[cfg(not(target_arch = "riscv32"))]
+                () => $lo(bits as usize),
+            }
+        }
+    };
+}
+
 macro_rules! set_pmp {
     () => {
         /// Set the pmp configuration corresponding to the index.

--- a/riscv/src/register/mcycle.rs
+++ b/riscv/src/register/mcycle.rs
@@ -3,4 +3,4 @@
 read_csr_as_usize!(0xB00);
 write_csr_as_usize!(0xB00);
 read_composite_csr!(super::mcycleh::read(), read());
-write_composite_csr!(|bits| super::mcycleh::write(bits), |bits| write(bits));
+write_composite_csr!(super::mcycleh::write, write);

--- a/riscv/src/register/mcycle.rs
+++ b/riscv/src/register/mcycle.rs
@@ -1,4 +1,5 @@
 //! mcycle register
 
 read_csr_as_usize!(0xB00);
+write_csr_as_usize!(0xB00);
 read_composite_csr!(super::mcycleh::read(), read());

--- a/riscv/src/register/mcycle.rs
+++ b/riscv/src/register/mcycle.rs
@@ -3,3 +3,4 @@
 read_csr_as_usize!(0xB00);
 write_csr_as_usize!(0xB00);
 read_composite_csr!(super::mcycleh::read(), read());
+write_composite_csr!(|bits| super::mcycleh::write(bits), |bits| write(bits));

--- a/riscv/src/register/mcycleh.rs
+++ b/riscv/src/register/mcycleh.rs
@@ -1,3 +1,4 @@
 //! mcycleh register
 
 read_csr_as_usize_rv32!(0xB80);
+write_csr_as_usize_rv32!(0xB80);

--- a/riscv/src/register/minstret.rs
+++ b/riscv/src/register/minstret.rs
@@ -3,4 +3,4 @@
 read_csr_as_usize!(0xB02);
 write_csr_as_usize!(0xB02);
 read_composite_csr!(super::minstreth::read(), read());
-write_composite_csr!(|bits| super::minstreth::write(bits), |bits| write(bits));
+write_composite_csr!(super::minstreth::write, write);

--- a/riscv/src/register/minstret.rs
+++ b/riscv/src/register/minstret.rs
@@ -1,4 +1,5 @@
 //! minstret register
 
 read_csr_as_usize!(0xB02);
+write_csr_as_usize!(0xB02);
 read_composite_csr!(super::minstreth::read(), read());

--- a/riscv/src/register/minstret.rs
+++ b/riscv/src/register/minstret.rs
@@ -3,3 +3,4 @@
 read_csr_as_usize!(0xB02);
 write_csr_as_usize!(0xB02);
 read_composite_csr!(super::minstreth::read(), read());
+write_composite_csr!(|bits| super::minstreth::write(bits), |bits| write(bits));

--- a/riscv/src/register/minstreth.rs
+++ b/riscv/src/register/minstreth.rs
@@ -1,3 +1,4 @@
 //! minstreth register
 
 read_csr_as_usize_rv32!(0xB82);
+write_csr_as_usize_rv32!(0xB82);


### PR DESCRIPTION
The RISC-V Instruction Set Manual Volume II: Privileged Architecture 20240411 specifies mcycle and minstret as "MRW" for read-write, instead of "MRO" for read-only. Therefore these registers should be writable.

Quick question: should there be also a `write_composite_csr` function for these registers since they are 64-bit registers even on 32-bit targets? That macro didn't exist so far but I could add it. Notably, just being able to write the lower bits is useful.