### PR TITLE
`riscv-rt`: add interrupts and exceptions to `link.x` only when required

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: cargo test --package tests
         

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Linker file now refers to standard exceptions and interrupts only when the
+  `no-exceptions` and `no-interrupts` features are disabled, respectively.
+  This is achieved by substituting `${INCLUDE_LINKER_FILES}` with the contents
+  of `exceptions.x` and/or `interrupts.x`.
+
 ## [v0.14.0] - 2025-02-18
 
 ### Changed

--- a/riscv-rt/build.rs
+++ b/riscv-rt/build.rs
@@ -11,9 +11,24 @@ fn add_linker_script(arch_width: u32) -> io::Result<()> {
     let mut content = fs::read_to_string("link.x.in")?;
     content = content.replace("${ARCH_WIDTH}", &arch_width.to_string());
 
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    // Get target-dependent linker configuration and replace ${INCLUDE_LINKER_FILES} with it
+    let mut include_content = String::new();
+
+    // If no-exceptions is disabled, include the exceptions.x files
+    if env::var_os("CARGO_FEATURE_NO_EXCEPTIONS").is_none() {
+        let exceptions_content = fs::read_to_string("exceptions.x")?;
+        include_content.push_str(&(exceptions_content + "\n"));
+    }
+    // If no-interrupts is disabled, include the interrupts.x files
+    if env::var_os("CARGO_FEATURE_NO_INTERRUPTS").is_none() {
+        let interrupts_content = fs::read_to_string("interrupts.x")?;
+        include_content.push_str(&(interrupts_content + "\n"));
+    }
+
+    content = content.replace("${INCLUDE_LINKER_FILES}", &include_content);
 
     // Put the linker script somewhere the linker can find it
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     fs::write(out_dir.join("link.x"), content)?;
     println!("cargo:rustc-link-search={}", out_dir.display());
     println!("cargo:rerun-if-changed=link.x");

--- a/riscv-rt/exceptions.x
+++ b/riscv-rt/exceptions.x
@@ -1,0 +1,23 @@
+/* # EXCEPTION HANDLERS DESCRIBED IN THE STANDARD RISC-V ISA
+   
+   If the `no-exceptions` feature is DISABLED, this file will be included in link.x.in.
+   If the `no-exceptions` feature is ENABLED, this file will be ignored.
+*/
+
+/* It is possible to define a special handler for each exception type.
+   By default, all exceptions are handled by ExceptionHandler. However,
+   users can override these alias by defining the symbol themselves */
+PROVIDE(InstructionMisaligned = ExceptionHandler);
+PROVIDE(InstructionFault = ExceptionHandler);
+PROVIDE(IllegalInstruction = ExceptionHandler);
+PROVIDE(Breakpoint = ExceptionHandler);
+PROVIDE(LoadMisaligned = ExceptionHandler);
+PROVIDE(LoadFault = ExceptionHandler);
+PROVIDE(StoreMisaligned = ExceptionHandler);
+PROVIDE(StoreFault = ExceptionHandler);
+PROVIDE(UserEnvCall = ExceptionHandler);
+PROVIDE(SupervisorEnvCall = ExceptionHandler);
+PROVIDE(MachineEnvCall = ExceptionHandler);
+PROVIDE(InstructionPageFault = ExceptionHandler);
+PROVIDE(LoadPageFault = ExceptionHandler);
+PROVIDE(StorePageFault = ExceptionHandler);

--- a/riscv-rt/interrupts.x
+++ b/riscv-rt/interrupts.x
@@ -1,0 +1,25 @@
+/* # CORE INTERRUPT HANDLERS DESCRIBED IN THE STANDARD RISC-V ISA
+   
+   If the `no-interrupts` feature is DISABLED, this file will be included in link.x.in.
+   If the `no-interrupts` feature is ENABLED, this file will be ignored.
+*/
+
+/* It is possible to define a special handler for each interrupt type.
+   By default, all interrupts are handled by DefaultHandler. However, users can
+   override these alias by defining the symbol themselves */
+PROVIDE(SupervisorSoft = DefaultHandler);
+PROVIDE(MachineSoft = DefaultHandler);
+PROVIDE(SupervisorTimer = DefaultHandler);
+PROVIDE(MachineTimer = DefaultHandler);
+PROVIDE(SupervisorExternal = DefaultHandler);
+PROVIDE(MachineExternal = DefaultHandler);
+
+/* When vectored trap mode is enabled, each interrupt source must implement its own
+   trap entry point. By default, all interrupts start in _DefaultHandler_trap.
+   However, users can override these alias by defining the symbol themselves */
+PROVIDE(_start_SupervisorSoft_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_MachineSoft_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_SupervisorTimer_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_MachineTimer_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_SupervisorExternal_trap = _start_DefaultHandler_trap);
+PROVIDE(_start_MachineExternal_trap = _start_DefaultHandler_trap);

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -22,73 +22,33 @@
   means that you won't see "Address (..) is out of bounds" in the disassembly produced by `objdump`.
 */
 
-PROVIDE(_stext = ORIGIN(REGION_TEXT));
-PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
-PROVIDE(_max_hart_id = 0);
-PROVIDE(_hart_stack_size = 2K);
-PROVIDE(_heap_size = 0);
-
-/** TRAP ENTRY POINTS **/
-
 /* Default trap entry point. The riscv-rt crate provides a weak alias of this function,
    which saves caller saved registers, calls _start_trap_rust, restores caller saved registers
    and then returns. Users can override this alias by defining the symbol themselves */
 EXTERN(_start_trap);
 
-/* Default interrupt trap entry point. When vectored trap mode is enabled,
-   the riscv-rt crate provides an implementation of this function, which saves caller saved
-   registers, calls the the DefaultHandler ISR, restores caller saved registers and returns. */
-PROVIDE(_start_DefaultHandler_trap = _start_trap);
-
-/* When vectored trap mode is enabled, each interrupt source must implement its own
-   trap entry point. By default, all interrupts start in _start_trap. However, users can
-   override these alias by defining the symbol themselves */
-PROVIDE(_start_SupervisorSoft_trap = _start_DefaultHandler_trap);
-PROVIDE(_start_MachineSoft_trap = _start_DefaultHandler_trap);
-PROVIDE(_start_SupervisorTimer_trap = _start_DefaultHandler_trap);
-PROVIDE(_start_MachineTimer_trap = _start_DefaultHandler_trap);
-PROVIDE(_start_SupervisorExternal_trap = _start_DefaultHandler_trap);
-PROVIDE(_start_MachineExternal_trap = _start_DefaultHandler_trap);
-
-/** EXCEPTION HANDLERS **/
-
 /* Default exception handler. The riscv-rt crate provides a weak alias of this function,
    which is a busy loop. Users can override this alias by defining the symbol themselves */
 EXTERN(ExceptionHandler);
-
-/* It is possible to define a special handler for each exception type.
-   By default, all exceptions are handled by ExceptionHandler. However, users can
-   override these alias by defining the symbol themselves */
-PROVIDE(InstructionMisaligned = ExceptionHandler);
-PROVIDE(InstructionFault = ExceptionHandler);
-PROVIDE(IllegalInstruction = ExceptionHandler);
-PROVIDE(Breakpoint = ExceptionHandler);
-PROVIDE(LoadMisaligned = ExceptionHandler);
-PROVIDE(LoadFault = ExceptionHandler);
-PROVIDE(StoreMisaligned = ExceptionHandler);
-PROVIDE(StoreFault = ExceptionHandler);
-PROVIDE(UserEnvCall = ExceptionHandler);
-PROVIDE(SupervisorEnvCall = ExceptionHandler);
-PROVIDE(MachineEnvCall = ExceptionHandler);
-PROVIDE(InstructionPageFault = ExceptionHandler);
-PROVIDE(LoadPageFault = ExceptionHandler);
-PROVIDE(StorePageFault = ExceptionHandler);
-
-/** INTERRUPT HANDLERS **/
 
 /* Default interrupt handler. The riscv-rt crate provides a weak alias of this function,
    which is a busy loop. Users can override this alias by defining the symbol themselves */
 EXTERN(DefaultHandler);
 
-/* It is possible to define a special handler for each interrupt type.
-   By default, all interrupts are handled by DefaultHandler. However, users can
-   override these alias by defining the symbol themselves */
-PROVIDE(SupervisorSoft = DefaultHandler);
-PROVIDE(MachineSoft = DefaultHandler);
-PROVIDE(SupervisorTimer = DefaultHandler);
-PROVIDE(MachineTimer = DefaultHandler);
-PROVIDE(SupervisorExternal = DefaultHandler);
-PROVIDE(MachineExternal = DefaultHandler);
+/* Default interrupt trap entry point. When vectored trap mode is enabled,
+   the riscv-rt crate provides an implementation of this function, which saves caller saved
+   registers, calls the the DefaultHandler ISR, restores caller saved registers and returns.
+   Note, however, that this provided implementation cannot be overwritten. We use PROVIDE
+   to avoid compilation errors in direct mode, not to allow users to overwrite the symbol. */
+PROVIDE(_start_DefaultHandler_trap = _start_trap);
+
+${INCLUDE_LINKER_FILES}
+
+PROVIDE(_stext = ORIGIN(REGION_TEXT));
+PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
+PROVIDE(_max_hart_id = 0);
+PROVIDE(_hart_stack_size = 2K);
+PROVIDE(_heap_size = 0);
 
 SECTIONS
 {

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -601,7 +601,7 @@ impl RiscvPacItem {
                             parse_quote!(&riscv_rt::TrapFrame),
                             parse_quote!(&mut riscv_rt::TrapFrame),
                         ];
-                        expected_types.iter().any(|t| first_param_type == *t)
+                        expected_types.contains(&first_param_type)
                     }
                     Some(_) => false,
                     None => true,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 riscv = { path = "../riscv", version = "0.13.0" }
 riscv-rt = { path = "../riscv-rt", version = "0.14.0", features = ["no-exceptions", "no-interrupts"]}
 trybuild = "1.0"
+
+[features]
+v-trap = ["riscv-rt/v-trap"]

--- a/tests/tests/riscv-rt/core_interrupt/fail_signatures.stderr
+++ b/tests/tests/riscv-rt/core_interrupt/fail_signatures.stderr
@@ -2,16 +2,16 @@ error: `#[core_interrupt]` function must have signature `[unsafe] fn() [-> !]`
  --> tests/riscv-rt/core_interrupt/fail_signatures.rs:2:1
   |
 2 | fn my_interrupt(code: usize) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^
 
 error: `#[core_interrupt]` function must have signature `[unsafe] fn() [-> !]`
  --> tests/riscv-rt/core_interrupt/fail_signatures.rs:5:1
   |
 5 | fn my_other_interrupt() -> usize {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^
 
 error: `#[core_interrupt]` function must have signature `[unsafe] fn() [-> !]`
  --> tests/riscv-rt/core_interrupt/fail_signatures.rs:8:1
   |
 8 | async fn my_async_interrupt() {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^^^

--- a/tests/tests/riscv-rt/exception/fail_signatures.stderr
+++ b/tests/tests/riscv-rt/exception/fail_signatures.stderr
@@ -2,16 +2,16 @@ error: `#[exception]` function must have signature `[unsafe] fn([&[mut] riscv_rt
  --> tests/riscv-rt/exception/fail_signatures.rs:2:1
   |
 2 | fn my_exception(code: usize) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^
 
 error: `#[exception]` function must have signature `[unsafe] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
  --> tests/riscv-rt/exception/fail_signatures.rs:5:1
   |
 5 | fn my_other_exception(trap_frame: &riscv_rt::TrapFrame, code: usize) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^
 
 error: `#[exception]` function must have signature `[unsafe] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
  --> tests/riscv-rt/exception/fail_signatures.rs:8:1
   |
 8 | async fn my_async_exception(trap_frame: &riscv_rt::TrapFrame, code: usize) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^^^

--- a/tests/tests/riscv-rt/external_interrupt/fail_signatures.stderr
+++ b/tests/tests/riscv-rt/external_interrupt/fail_signatures.stderr
@@ -2,16 +2,16 @@ error: `#[external_interrupt]` function must have signature `[unsafe] fn() [-> !
   --> tests/riscv-rt/external_interrupt/fail_signatures.rs:31:1
    |
 31 | fn my_interrupt() -> usize {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^
 
 error: `#[external_interrupt]` function must have signature `[unsafe] fn() [-> !]`
   --> tests/riscv-rt/external_interrupt/fail_signatures.rs:34:1
    |
 34 | fn my_other_interrupt(code: usize) -> usize {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^
 
 error: `#[external_interrupt]` function must have signature `[unsafe] fn() [-> !]`
   --> tests/riscv-rt/external_interrupt/fail_signatures.rs:37:1
    |
 37 | async fn my_async_interrupt(code: usize) -> usize {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^


### PR DESCRIPTION
As now core interrupts and exceptions can be re-defined in PACs to adapt to different targets, I thought it would be a good idea to clean the linker script and only add weak bindings to standard exceptions and interrupts when these are not disabled via the `no-exceptions` and `no-interrupts` features.

Now, in the `build.rs` script, we check if the `no-interrupts` and `no-exceptions` features are enabled. If not, we copy-paste the content of the new `interrupts.x` and `exceptions.x` files, respectively.

This is not a breaking change, it should work the same way. In fact, it might help find bugs in PACs that define partially their custom interrupt or exceptions.