### PR TITLE
_pre_init_trap defaults to _default_abort

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `no-exceptions` and `no-interrupts` features are disabled, respectively.
   This is achieved by substituting `${INCLUDE_LINKER_FILES}` with the contents
   of `exceptions.x` and/or `interrupts.x`.
+- Add global `_default_abort` symbol, `PROVIDE(abort = _default_abort)` to avoid
+  using weak symbols ([#247](https://github.com/rust-embedded/riscv/issues/247))
+- Replace weak definitions of `DefaultHandler` and `ExceptionHandler`
+  with `PROVIDE(... = abort)`.
+- Replace weak definition of `_pre_init_trap` with `PROVIDE(_pre_init_trap =  _default_abort)`.
+- Now, `_default_abort` is 4-byte aligned (required by `_pre_init_trap`)
+- Removed `.init.trap` section, as it is no longer required.
 
 ## [v0.14.0] - 2025-02-18
 
@@ -62,8 +69,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   allow users get the initial address of the heap when initializing an allocator.
 - Update documentation.
 - Removed `.init.rust` section, as it is no longer required.
-- Add global `_abort` symbol, `PROVIDE(abort = _abort)`, and replace `DefaultHandler` and
-  `ExceptionHandler` with `PROVIDE(... = abort)`.
 
 ## [v0.13.0] - 2024-10-19
 

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -22,9 +22,14 @@
   means that you won't see "Address (..) is out of bounds" in the disassembly produced by `objdump`.
 */
 
-/* Default abort entry point. If no abort symbol is provided, then abort maps to _abort. */
+/* Default abort entry point. If no abort symbol is provided, then abort maps to _default_abort. */
 EXTERN(_default_abort);
 PROVIDE(abort = _default_abort);
+
+/* Trap for exceptions triggered during initialization. If the execution reaches this point, it
+   means that there is a bug in the boot code. If no _pre_init_trap symbol is provided, then
+  _pre_init_trap defaults to _default_abort. Note that _pre_init_trap must be 4-byte aligned */
+PROVIDE(_pre_init_trap = _default_abort);
 
 /* Default trap entry point. The riscv-rt crate provides a weak alias of this function,
    which saves caller saved registers, calls _start_trap_rust, restores caller saved registers
@@ -70,11 +75,9 @@ SECTIONS
     /* point of the program. */
     KEEP(*(.init));
     . = ALIGN(4);
-    KEEP(*(.init.trap));
-    . = ALIGN(4);
     *(.trap);
     *(.trap.rust);
-    *(.text.abort);
+    *(.text.abort); /* close to .init section to support j abort */
     *(.text .text.*);
 
     . = ALIGN(4);
@@ -188,6 +191,9 @@ BUG(riscv-rt): .bss is not ${ARCH_WIDTH}-byte aligned");
 
 ASSERT(__sheap % 4 == 0, "
 BUG(riscv-rt): start of .heap is not 4-byte aligned");
+
+ASSERT(_pre_init_trap % 4 == 0, "
+BUG(riscv-rt): _pre_init_trap is not 4-byte aligned");
 
 ASSERT(_stext + SIZEOF(.text) < ORIGIN(REGION_TEXT) + LENGTH(REGION_TEXT), "
 ERROR(riscv-rt): The .text section must be placed inside the REGION_TEXT region.

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -251,13 +251,6 @@ _setup_interrupts:",
     #[cfg(not(feature = "s-mode"))]
     "csrw mtvec, t0",
     "ret",
-    // Default implementation of `_pre_init_trap` is an infinite loop.
-    // Users can override this function by defining their own `_pre_init_trap`
-    // If the execution reaches this point, it means that there is a bug in the boot code.
-    ".section .init.trap, \"ax\"
-    .weak _pre_init_trap
-_pre_init_trap:
-    j _pre_init_trap",
 );
 
 riscv_rt_macros::weak_start_trap!();
@@ -268,6 +261,7 @@ riscv_rt_macros::vectored_interrupt_trap!();
 #[rustfmt::skip]
 global_asm!(
     ".section .text.abort
+.align 4
 .global _default_abort
 _default_abort:  // make sure there is an abort symbol when linking
     j _default_abort"

--- a/riscv-target-parser/CHANGELOG.md
+++ b/riscv-target-parser/CHANGELOG.md
@@ -5,7 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix links to URLs in docs
+
 ## [v0.1.1] - 2025-03-18
+
 ### Fixed
 
 - Fix parsing of extensions starting with 's'/'x'/'z' from target features 

--- a/riscv-target-parser/src/lib.rs
+++ b/riscv-target-parser/src/lib.rs
@@ -189,9 +189,9 @@ impl RiscvTarget {
     ///
     /// # Related issues
     ///
-    /// - https://github.com/rust-embedded/riscv/issues/175
-    /// - https://github.com/rust-lang/rust/issues/80608
-    /// - https://github.com/llvm/llvm-project/issues/61991
+    /// - <https://github.com/rust-embedded/riscv/issues/175>
+    /// - <https://github.com/rust-lang/rust/issues/80608>
+    /// - <https://github.com/llvm/llvm-project/issues/61991>
     pub fn llvm_arch_patch(&self) -> String {
         let mut patch = self.llvm_base_isa();
         if self.extensions.contains(&Extension::M) {


### PR DESCRIPTION
Following the rework required to close #247 

Now, `_pre_init_trap` defaults to `_default_abort`, which is 4-byte aligned to ensure that we comply with the requirements of the `xtvec` register.