### PR TITLE
Simplify `riscv::interrupt::machine::nested`

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - CSR helper macro `write_composite_csr` for writing 64-bit CSRs on 32-bit targets.
 - Write utilities for `mcycle`, `minstret`
 
+### Changed
+
+- Simplify `riscv::interrupt::machine::nested`
+
 ## [v0.13.0] - 2025-02-18
 
 ### Added

--- a/riscv/src/interrupt/machine.rs
+++ b/riscv/src/interrupt/machine.rs
@@ -192,12 +192,10 @@ where
     }
 
     // Restore MSTATUS.PIE, MSTATUS.MPP, and SEPC
-    let mut after_mstatus = mstatus::read();
     if mstatus.mpie() {
-        after_mstatus.set_mpie(mstatus.mpie());
+        mstatus::set_mpie();
     }
-    after_mstatus.set_mpp(mstatus.mpp());
-    mstatus::write(after_mstatus);
+    mstatus::set_mpp(mstatus.mpp());
     mepc::write(mepc);
 
     r


### PR DESCRIPTION
Just simplify the `nested` function for M-mode, following the same fashion as for S-mode.