### PR TITLE
`riscv-rt`: Remove weak symbol for _mp_hook

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   they must enable the `pre-init` feature.
 - Deprecate `riscv_rt::pre_init` attribute macro. It is not sound to run Rust code before initializing the RAM.
   Instead, we recommend defining the `__pre_init` function with `core::arch::global_asm!`.
+- Replace weak definition of `_mp_hook` with `PROVIDE(_mp_hook = _default_mp_hook)`.
 
 ### Fixed
 

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -31,6 +31,14 @@ PROVIDE(abort = _default_abort);
   _pre_init_trap defaults to _default_abort. Note that _pre_init_trap must be 4-byte aligned */
 PROVIDE(_pre_init_trap = _default_abort);
 
+/* Multi-processor hook function (for multi-core targets only). If no _mp_hook symbol
+   is provided, then _mp_hook maps to _default_mp_hook, which leaves HART 0 running while
+   the other HARTS stuck in a busy loop. Note that _default_mp_hook cannot be overwritten.
+   We use PROVIDE to avoid compilation errors in single hart targets, not to allow users
+   to overwrite the symbol. */
+PROVIDE(_default_mp_hook = abort);
+PROVIDE(_mp_hook = _default_mp_hook);
+
 /* Default trap entry point. If not _start_trap symbol is provided, then _start_trap maps to
    _default_start_trap, which saves caller saved registers, calls _start_trap_rust, restores
    caller saved registers and then returns. Note that _start_trap must be 4-byte aligned */

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -226,8 +226,8 @@ cfg_global_asm!(
     // Default implementation of `_mp_hook` wakes hart 0 and busy-loops all the other harts.
     // Users can override this function by defining their own `_mp_hook`.
     // This function is only used when the `single-hart` feature is not enabled.
-    ".weak _mp_hook
-_mp_hook:
+    ".global _default_mp_hook
+_default_mp_hook:
     beqz a0, 2f // if hartid is 0, return true
 1:  wfi // Otherwise, wait for interrupt in a loop
     j 1b


### PR DESCRIPTION
Closes #247 