### PR TITLE
`riscv-peripheral`: utility function to get `MTIME` frequency from `MTIMER` peripheral

### DIFF
--- a/riscv-peripheral/src/aclint/mtimer.rs
+++ b/riscv-peripheral/src/aclint/mtimer.rs
@@ -56,6 +56,12 @@ impl<M: Mtimer> MTIMER<M> {
         M::MTIMECMP_BASE as *const u64
     }
 
+    /// Returns the clock frequency of the `MTIME` register.
+    #[inline]
+    pub const fn mtime_freq(self) -> usize {
+        M::MTIME_FREQ
+    }
+
     /// Returns `true` if a machine timer interrupt is pending.
     #[inline]
     pub fn is_interrupting(self) -> bool {


### PR DESCRIPTION
While working on adapting the `e310x-hal` to this new approach, I found it would be useful to expose the `MTIME_FREQ` with a method to avoid using weird `riscv_peripheral::MTIMER::<Clint>::MTIME_FREQ` things.