### PR TITLE
register: add `mtval2` register

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `scontext` CSR
 - Add `mconfigptr` CSR
 - Bump MSRV to 1.67.0 for `log` to `ilog` name change
+- Add `mtval2` CSR
 
 ### Changed
 

--- a/riscv/src/register.rs
+++ b/riscv/src/register.rs
@@ -90,6 +90,7 @@ pub mod mip;
 pub mod mscratch;
 pub mod mtinst;
 pub mod mtval;
+pub mod mtval2;
 
 // Machine Protection and Translation
 mod pmpcfgx;

--- a/riscv/src/register/mtval2.rs
+++ b/riscv/src/register/mtval2.rs
@@ -1,0 +1,23 @@
+//! mtval register
+
+const MASK: usize = usize::MAX;
+
+read_only_csr! {
+    /// mtval2 register
+    Mtval2: 0x348,
+    mask: MASK,
+}
+
+impl Mtval2 {
+    /// Represents the bitshift value of the guest-page address stored in `mtval2`.
+    pub const GUEST_PAGE_SHIFT: usize = 2;
+
+    /// Gets the guest-page fault physical address.
+    ///
+    /// # Note
+    ///
+    /// The address is written when an invalid implicit memory access during address translation.
+    pub const fn guest_fault_address(&self) -> usize {
+        self.bits() << Self::GUEST_PAGE_SHIFT
+    }
+}

--- a/riscv/src/register/mtval2.rs
+++ b/riscv/src/register/mtval2.rs
@@ -21,3 +21,22 @@ impl Mtval2 {
         self.bits() << Self::GUEST_PAGE_SHIFT
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mtval2() {
+        (1..=usize::BITS)
+            .map(|r| ((1u128 << r) - 1) as usize)
+            .for_each(|bits| {
+                let mtval2 = Mtval2::from_bits(bits);
+                assert_eq!(mtval2.bits(), bits);
+                assert_eq!(
+                    mtval2.guest_fault_address(),
+                    bits << Mtval2::GUEST_PAGE_SHIFT
+                );
+            });
+    }
+}


### PR DESCRIPTION
Adds the definition for the `mtval2` Machine trap value 2 CSR.

Adds basic unit tests for the `mtval2` CSR.

Related: #1