### PR TITLE
Correct hart_stack_size assertion

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Main function no longer needs to be close to _start. A linker script may copy
   all code to RAM and keep .init in flash/ROM.
+- By default, the stack is now split into equal parts based on the number of
+  harts.
 
 ### Fixed
 

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -72,7 +72,7 @@ ${INCLUDE_LINKER_FILES}
 PROVIDE(_stext = ORIGIN(REGION_TEXT));
 PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
 PROVIDE(_max_hart_id = 0);
-PROVIDE(_hart_stack_size = 2K);
+PROVIDE(_hart_stack_size = SIZEOF(.stack) / (_max_hart_id + 1));
 PROVIDE(_heap_size = 0);
 
 SECTIONS

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -90,7 +90,10 @@
 //!
 //! This symbol defines stack area size for *one* hart.
 //!
-//! If omitted this symbol value will default to 2K.
+//! If omitted this symbol value will default to `SIZEOF(.stack) / (_max_hart_id + 1)`.
+//!
+//! Note that due to alignment, each individual stack may differ slightly in
+//! size.
 //!
 //! ### `_stack_start`
 //!


### PR DESCRIPTION
Solves #295.

Corrected the assert such that the stack can be divided exactly in the number of harts. Also set the default hart stack size to this value.