### PR TITLE
Use la/jr pseudoinstructions for main function call

### DIFF
--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -217,7 +217,8 @@ cfg_global_asm!(
     ld a1, 8 * 1(sp)
     ld a2, 8 * 2(sp)
     addi sp, sp, 8 * 4",
-    "jal zero, main
+    "la t0, main
+    jr t0
     .cfi_endproc",
 );
 


### PR DESCRIPTION
Replace direct jal with load address and jump register pseudoinstructions to support main functions located beyond the ±1MB range of direct jumps.

Together with a custom link script, this allows placing the bulk of the code in RAM which is likely located far away.

I use it for loading everything from a very slow SPI flash into SRAM on an FPGA. But it's useful for things like decreasing power consumption by powering off flash as well.