### PR TITLE
`riscv-rt`: copy hart ID to `a0` in M-mode

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   all code to RAM and keep .init in flash/ROM.
 - By default, the stack is now split into equal parts based on the number of
   harts.
+- In M-mode, the hart ID is moved to `a0` at the beginning of the runtime.
 
 ### Fixed
 


### PR DESCRIPTION
Minor change that simplifies the assembly code.

At the beginning of the runtime, we assume that, in S-mode, the hart ID is provided by the previous bootload via `a0`. This is not true in M-mode. This PR copies `mhartid` to `a0` at the beginning of runtime, allowing the rest of the code to be the same in both S-mode and M-mode.