### PR TITLE
`riscv-rt`: validate hard ID earlier and allow `abort` to be located anywhere

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Main function no longer needs to be close to _start. A linker script may copy
-  all code to RAM and keep .init in flash/ROM.
+- `main` function no longer needs to be close to `_start`. A linker script may copy
+  all code to RAM and keep `.init` in flash/ROM.
 - By default, the stack is now split into equal parts based on the number of
   harts.
 - In M-mode, the hart ID is moved to `a0` at the beginning of the runtime.
+- `abort` function no longer needs to be close to `_start`.
+- In multi-hart targets, the hart ID is now validated earlier in the boot process.
 
 ### Fixed
 

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -72,6 +72,14 @@ _abs_start:
     "csrw stvec, t0",
     #[cfg(not(feature = "s-mode"))]
     "csrw mtvec, t0",
+    // If multi-hart, assert that hart ID is valid
+    #[cfg(not(feature = "single-hart"))]
+    "lui t0, %hi(_max_hart_id)
+    add t0, t0, %lo(_max_hart_id)
+    bgeu t0, a0, 1f
+    la t0, abort // If hart_id > _max_hart_id, jump to abort
+    jr t0
+1:", // only valid harts reach this point
 );
 
 // ZERO OUT GENERAL-PURPOSE REGISTERS
@@ -91,9 +99,6 @@ cfg_global_asm!(
 #[cfg(not(feature = "single-hart"))]
 cfg_global_asm!(
     "mv t2, a0
-    lui t0, %hi(_max_hart_id)
-    add t0, t0, %lo(_max_hart_id)
-    bgtu t2, t0, abort
     lui t0, %hi(_hart_stack_size)
     add t0, t0, %lo(_hart_stack_size)",
     #[cfg(riscvm)]


### PR DESCRIPTION
This PR moves the hart ID validation earlier in the boot process. Furthermore, as suggested by @janderholm , now `abort` can be located anywhere. This change may be especially important for targets with huge memory (see #153)