### PR TITLE
`riscv-rt`: remove general-purpose register zeroing

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - In M-mode, the hart ID is moved to `a0` at the beginning of the runtime.
 - `abort` function no longer needs to be close to `_start`.
 - In multi-hart targets, the hart ID is now validated earlier in the boot process.
+- General purpose registers are no longer zeroed, as this is not strictly necessary.
+  This aligns with the `cortex-m-rt` crate.
 
 ### Fixed
 

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -82,13 +82,6 @@ _abs_start:
 1:", // only valid harts reach this point
 );
 
-// ZERO OUT GENERAL-PURPOSE REGISTERS
-riscv_rt_macros::loop_global_asm!("    li x{}, 0", 1, 10);
-// a0..a2 (x10..x12) skipped
-riscv_rt_macros::loop_global_asm!("    li x{}, 0", 13, 16);
-#[cfg(riscvi)]
-riscv_rt_macros::loop_global_asm!("    li x{}, 0", 16, 32);
-
 // INITIALIZE GLOBAL POINTER, STACK POINTER, AND FRAME POINTER
 cfg_global_asm!(
     ".option push
@@ -193,13 +186,6 @@ cfg_global_asm!(
     csrrs x0, mstatus, t2",
     "fscsr x0",
 );
-// ZERO OUT FLOATING POINT REGISTERS
-#[cfg(all(target_arch = "riscv32", riscvd))]
-riscv_rt_macros::loop_global_asm!("    fcvt.d.w f{}, x0", 32);
-#[cfg(all(target_arch = "riscv64", riscvd))]
-riscv_rt_macros::loop_global_asm!("    fmv.d.x f{}, x0", 32);
-#[cfg(all(riscvf, not(riscvd)))]
-riscv_rt_macros::loop_global_asm!("    fmv.w.x f{}, x0", 32);
 
 // SET UP INTERRUPTS, RESTORE a0..a2, AND JUMP TO MAIN RUST FUNCTION
 cfg_global_asm!(


### PR DESCRIPTION
To the best of my knowledge, zeroing general-purpose registers is not required at all. In fact, after zeroing them, the boot process uses a few temporary registers and leaves them dirty when jumping to main.

I checked the `cortex-m-rt` source code, and it seems that they do not clear general-purpose registers. Thus, I guess that it is not harmful to shrink the boot process a bit.