### PR TITLE
`riscv`: add Xtvec::new and Xtvec::try_new

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New convenience  `try_new` and `new` associated functions for `Mtvec` and `Stvec`.
+
 ### Changed
 
 - Use `cfg(any(target_arch = "riscv32", target_arch = "riscv64"))` instead of `cfg(riscv)`.

--- a/riscv/src/register/mtvec.rs
+++ b/riscv/src/register/mtvec.rs
@@ -28,6 +28,25 @@ read_write_csr_field! {
 }
 
 impl Mtvec {
+    /// Creates a new `Mtvec` with the given address and trap mode.
+    ///
+    /// # Note
+    ///
+    /// Panics if the address is not aligned to 4-bytes.
+    #[inline]
+    pub fn new(address: usize, trap_mode: TrapMode) -> Self {
+        Self::try_new(address, trap_mode).unwrap()
+    }
+
+    /// Attempts to create a new `Mtvec` with the given address and trap mode.
+    #[inline]
+    pub fn try_new(address: usize, trap_mode: TrapMode) -> Result<Self> {
+        let mut mtvec = Self::from_bits(0);
+        mtvec.try_set_address(address)?;
+        mtvec.set_trap_mode(trap_mode);
+        Ok(mtvec)
+    }
+
     /// Returns the trap-vector base-address
     #[inline]
     pub const fn address(&self) -> usize {

--- a/riscv/src/register/stvec.rs
+++ b/riscv/src/register/stvec.rs
@@ -19,6 +19,25 @@ read_write_csr_field! {
 }
 
 impl Stvec {
+    /// Creates a new `Stvec` with the given address and trap mode.
+    ///
+    /// # Note
+    ///
+    /// Panics if the address is not aligned to 4-bytes.
+    #[inline]
+    pub fn new(address: usize, trap_mode: TrapMode) -> Self {
+        Self::try_new(address, trap_mode).unwrap()
+    }
+
+    /// Attempts to create a new `Stvec` with the given address and trap mode.
+    #[inline]
+    pub fn try_new(address: usize, trap_mode: TrapMode) -> Result<Self> {
+        let mut stvec = Stvec::from_bits(0);
+        stvec.try_set_address(address)?;
+        stvec.set_trap_mode(trap_mode);
+        Ok(stvec)
+    }
+
     /// Returns the trap-vector base-address
     #[inline]
     pub const fn address(&self) -> usize {


### PR DESCRIPTION
Adds a few convenience functions to deal with `mtvec` and `xtvec` registers.