### PR TITLE
Join global_asm macro invocations

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `clippy` fixes
+- Merged `cfg_global_asm!` macro invocations to guarantee contiguous code generation.
 
 ## [v0.15.0] - 2025-06-10
 


### PR DESCRIPTION
Fixes #321

I intentionally didn't update the indentation, for two reasons:
1) I don't even know how this should be indented
2) This way it's easier to review

If you'd prefer some certain way of indenting the conditional blocks inside the `cfg_global_asm!` call, I'll happily update the pull request.