### PR TITLE
`riscv-rt`: Use `_start_rust` and `hal_main`

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -25,11 +25,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   4. `_start_DefaultHandler_trap` and `_continue_trap` (if `v-trap` is enabled).
   5. `_start_trap_rust`.
   6. Other code in `.trap` section (usually, none)
+- Now, `riscv-rt` jumps to `_start_rust` instead of `main` directly. This allows us
+  to leave input parameters preservation to the Rust compiler.
+- `_default_setup_interrupts` is now written in Rust and called from `_start_rust`.
+- Now, `_start_rust` jumps to `hal_main` instead of `main` directly. At linker level,
+  `hal_main` maps to `main` if not defined. However, we now allow HALs to inject
+  additional configuration code before jumping to the final user's `main` function.
 
 ### Fixed
 
 - `clippy` fixes
 - Merged `cfg_global_asm!` macro invocations to guarantee contiguous code generation.
+- Use `.balign` instead of `.align` in `_default_abort`
 
 ## [v0.15.0] - 2025-06-10
 

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -52,6 +52,11 @@ PROVIDE(_start_trap = _default_start_trap);
 EXTERN(_default_setup_interrupts);
 PROVIDE(_setup_interrupts = _default_setup_interrupts);
 
+/* Default main routine. If no hal_main symbol is provided, then hal_main maps to main, which
+   is usually defined by final users via the #[riscv_rt::entry] attribute. Using hal_main
+   instead of main directly allow HALs to inject code before jumping to user main. */
+PROVIDE(hal_main = main);
+
 /* Default exception handler. By default, the exception handler is abort.
    Users can override this alias by defining the symbol themselves */
 PROVIDE(ExceptionHandler = abort);


### PR DESCRIPTION
This PR goes back to using `_start_rust`, reducing the assembly code to the minimum. Also, inspired by `esp-riscv-rt`, now `_start_rust` jumps to `hal_main` instead of `main`. At linker level, if `hal_main` is not defined, it maps to `main`, so it would still work in the same was as of today.