### PR TITLE
`riscv-rt`: Preserve `a0-a2` in startup only when startup functions are expected

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Now, `_start_rust` jumps to `hal_main` instead of `main` directly. At linker level,
   `hal_main` maps to `main` if not defined. However, we now allow HALs to inject
   additional configuration code before jumping to the final user's `main` function.
+- Now, `a0-a2` are preserved in `s0-s2` during the startup process. In RVE targets,
+  `a2` is preserved in `a5`, as there are only two callee-saved registers.
+  New documentation of startup functions (`_mp_hook` and `__pre_init`) now provide
+  additional implementation guidelines to ensure a correct behavior of the runtime.
+
+### Removed
+
+- Removed usage of the stack before `_start_rust`. This was unsound, as in the `.init`
+  section RAM is still uninitialized.
 
 ### Fixed
 


### PR DESCRIPTION
Alternative to #325 . This is simpler, as it reduces register preservation to the minimum. New documentation specifies that registers `a1` and `a2` must not be modified during `_mp_hook` and `__pre_init`.

I personally prefer this over #325, but let me know your opinion.

Closes #315