### PR TITLE
`riscv-rt`: Add `__post_init`  Rust function

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `post-init` feature to run a Rust `__post_init` function before jumping to `main`.
+- New `#[riscv_rt::post_init]` attribute to aid in the definition of the `__post_init` function. 
+
 ### Changed
 
 - `main` function no longer needs to be close to `_start`. A linker script may copy

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -14,7 +14,7 @@ links = "riscv-rt" # Prevent multiple versions of riscv-rt being linked
 
 [package.metadata.docs.rs]
 default-target = "riscv64imac-unknown-none-elf"
-features = ["pre-init"]
+features = ["pre-init", "post-init"]
 targets = [
     "riscv32i-unknown-none-elf", "riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf",
     "riscv64imac-unknown-none-elf", "riscv64gc-unknown-none-elf",
@@ -33,6 +33,7 @@ panic-halt = "1.0.0"
 
 [features]
 pre-init = []
+post-init = []
 s-mode = ["riscv-rt-macros/s-mode"]
 single-hart = []
 v-trap = ["riscv-rt-macros/v-trap"]

--- a/tests-trybuild/Cargo.toml
+++ b/tests-trybuild/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 riscv = { path = "../riscv" }
-riscv-rt = { path = "../riscv-rt", features = ["no-exceptions", "no-interrupts"] }
+riscv-rt = { path = "../riscv-rt", features = ["no-exceptions", "no-interrupts", "post-init"] }
 trybuild = "1.0"
 
 [features]

--- a/tests-trybuild/tests/riscv-rt/post_init/fail_arg_count.rs
+++ b/tests-trybuild/tests/riscv-rt/post_init/fail_arg_count.rs
@@ -1,0 +1,4 @@
+#[riscv_rt::post_init]
+fn before_main(_hart_id: usize, _dtb: usize) {}
+
+fn main() {}

--- a/tests-trybuild/tests/riscv-rt/post_init/fail_arg_count.stderr
+++ b/tests-trybuild/tests/riscv-rt/post_init/fail_arg_count.stderr
@@ -1,0 +1,5 @@
+error: `#[post_init]` function has too many arguments
+ --> tests/riscv-rt/post_init/fail_arg_count.rs:2:33
+  |
+2 | fn before_main(_hart_id: usize, _dtb: usize) {}
+  |                                 ^^^^

--- a/tests-trybuild/tests/riscv-rt/post_init/fail_arg_type.rs
+++ b/tests-trybuild/tests/riscv-rt/post_init/fail_arg_type.rs
@@ -1,0 +1,4 @@
+#[riscv_rt::post_init]
+fn before_main(_hart_id: String) {}
+
+fn main() {}

--- a/tests-trybuild/tests/riscv-rt/post_init/fail_arg_type.stderr
+++ b/tests-trybuild/tests/riscv-rt/post_init/fail_arg_type.stderr
@@ -1,0 +1,5 @@
+error: argument type must be usize
+ --> tests/riscv-rt/post_init/fail_arg_type.rs:2:26
+  |
+2 | fn before_main(_hart_id: String) {}
+  |                          ^^^^^^

--- a/tests-trybuild/tests/riscv-rt/post_init/fail_async.rs
+++ b/tests-trybuild/tests/riscv-rt/post_init/fail_async.rs
@@ -1,0 +1,4 @@
+#[riscv_rt::post_init]
+async fn before_main() {}
+
+fn main() {}

--- a/tests-trybuild/tests/riscv-rt/post_init/fail_async.stderr
+++ b/tests-trybuild/tests/riscv-rt/post_init/fail_async.stderr
@@ -1,0 +1,5 @@
+error: `#[post_init]` function must have signature `[unsafe] fn([usize])`
+ --> tests/riscv-rt/post_init/fail_async.rs:2:1
+  |
+2 | async fn before_main() {}
+  | ^^^^^

--- a/tests-trybuild/tests/riscv-rt/post_init/pass_empty.rs
+++ b/tests-trybuild/tests/riscv-rt/post_init/pass_empty.rs
@@ -1,0 +1,4 @@
+#[riscv_rt::post_init]
+fn before_main() {}
+
+fn main() {}

--- a/tests-trybuild/tests/riscv-rt/post_init/pass_safe.rs
+++ b/tests-trybuild/tests/riscv-rt/post_init/pass_safe.rs
@@ -1,0 +1,4 @@
+#[riscv_rt::post_init]
+fn before_main(_hart_id: usize) {}
+
+fn main() {}

--- a/tests-trybuild/tests/riscv-rt/post_init/pass_unsafe.rs
+++ b/tests-trybuild/tests/riscv-rt/post_init/pass_unsafe.rs
@@ -1,0 +1,4 @@
+#[riscv_rt::post_init]
+unsafe fn before_main(_hart_id: usize) {}
+
+fn main() {}


### PR DESCRIPTION
Inspired by `esp-riscv-rt`. It includes a `__post_init` Rust function to perform initialization actions safely from Rust.

The new `__post_init` function is optional and feature-gated. If enabled, no default symbol is provided, and users must include this function. They can use the new `#[riscv_rt::post_init]` attribute macro. I included `trybuild` tests.