### PR TITLE
`riscv-rt`: Add uninit section

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - New `post-init` feature to run a Rust `__post_init` function before jumping to `main`.
 - New `#[riscv_rt::post_init]` attribute to aid in the definition of the `__post_init` function. 
+- Added `.uninit` section to the linker file. Due to its similarities with `.bss`, the
+  linker will place this new section in `REGION_BSS`.
 
 ### Changed
 

--- a/riscv-rt/link.x.in
+++ b/riscv-rt/link.x.in
@@ -161,6 +161,19 @@ SECTIONS
   . = ALIGN(${ARCH_WIDTH});
   __ebss = .;
 
+  /* Uninitialized data segment. In contrast with .bss, .uninit is not initialized to zero by
+   * the runtime, and might contain residual data from previous executions or random values
+   * if not explicitly initialized. While .bss and .uninit are different sections, they are
+   * both allocated at REGION_BSS, as their purpose is similar. */
+  .uninit (NOLOAD) : ALIGN(${ARCH_WIDTH})
+  {
+    . = ALIGN(${ARCH_WIDTH});
+    __suninit = .;
+    *(.uninit .uninit.*);
+    . = ALIGN(${ARCH_WIDTH});
+    __euninit = .;
+  } > REGION_BSS
+
   /* fictitious region that represents the memory available for the heap */
   .heap (NOLOAD) : ALIGN(4)
   {


### PR DESCRIPTION
I encountered linker errors trying to build RTIC examples on RISC-V. The reason was that the linker could not find any empty spot in RAM to place the `.uninit` section. This PR mimics the `.uninit` section of `cortex-m-rt`. The linker will put it in the same memory region as `.bss`, considering that both sections have a very similar purpose.