### PR TITLE
`riscv`: Use `riscv_pac::CoreInterrupt` in `mie` register

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New convenience  `try_new` and `new` associated functions for `Mtvec` and `Stvec`.
 - New methods and functions for enabling core interrupts in the `mie` and `sie` registers
   using the `riscv_pac::CoreInterrupt` trait.
-- New `riscv::interrupt::{disable_interrupt, enable_interrupt}` functions.
+- New `riscv::interrupt::{is_interrupt_enabled, disable_interrupt, enable_interrupt}` functions.
 
 ### Changed
 

--- a/riscv/src/interrupt/machine.rs
+++ b/riscv/src/interrupt/machine.rs
@@ -96,11 +96,16 @@ unsafe impl ExceptionNumber for Exception {
     }
 }
 
+/// Checks if a specific core interrupt source is enabled in the current hart (machine mode).
+#[inline]
+pub fn is_interrupt_enabled<I: CoreInterruptNumber>(interrupt: I) -> bool {
+    mie::read().is_enabled(interrupt)
+}
+
 /// Disables interrupts for a specific core interrupt source in the current hart (machine mode).
 #[inline]
 pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
-    // SAFETY: it is safe to disable an interrupt source
-    mie::disable_interrupt(interrupt);
+    mie::disable(interrupt);
 }
 
 /// Enables interrupts for a specific core interrupt source in the current hart (machine mode).
@@ -115,7 +120,7 @@ pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
 /// Ensure that this is called in a safe context where interrupts can be enabled.
 #[inline]
 pub unsafe fn enable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
-    mie::enable_interrupt(interrupt);
+    mie::enable(interrupt);
 }
 
 /// Disables interrupts globally in the current hart (machine mode).

--- a/riscv/src/interrupt/supervisor.rs
+++ b/riscv/src/interrupt/supervisor.rs
@@ -88,11 +88,17 @@ unsafe impl ExceptionNumber for Exception {
     }
 }
 
+/// Checks if a specific core interrupt source is enabled in the current hart (supervisor mode).
+#[inline]
+pub fn is_interrupt_enabled<I: CoreInterruptNumber>(interrupt: I) -> bool {
+    sie::read().is_enabled(interrupt)
+}
+
 /// Disables interrupts for a specific core interrupt source in the current hart (supervisor mode).
 #[inline]
 pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
     // SAFETY: it is safe to disable an interrupt source
-    sie::disable_interrupt(interrupt);
+    sie::disable(interrupt);
 }
 
 /// Enables interrupts for a specific core interrupt source in the current hart (supervisor mode).
@@ -107,7 +113,7 @@ pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
 /// Ensure that this is called in a safe context where interrupts can be enabled.
 #[inline]
 pub unsafe fn enable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
-    sie::enable_interrupt(interrupt);
+    sie::enable(interrupt);
 }
 
 /// Disables interrupts globally in the current hart (supervisor mode).

--- a/riscv/src/register/mie.rs
+++ b/riscv/src/register/mie.rs
@@ -89,7 +89,7 @@ set_clear_csr!(
 
 /// Disables a specific core interrupt source.
 #[inline]
-pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
+pub fn disable<I: CoreInterruptNumber>(interrupt: I) {
     // SAFETY: it is safe to disable an interrupt source
     unsafe { _clear(1 << interrupt.number()) };
 }
@@ -101,7 +101,7 @@ pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
 /// Enabling interrupts might break critical sections or other synchronization mechanisms.
 /// Ensure that this is called in a safe context where interrupts can be enabled.
 #[inline]
-pub unsafe fn enable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
+pub unsafe fn enable<I: CoreInterruptNumber>(interrupt: I) {
     unsafe { _set(1 << interrupt.number()) };
 }
 

--- a/riscv/src/register/sie.rs
+++ b/riscv/src/register/sie.rs
@@ -62,7 +62,7 @@ set_clear_csr!(
 
 /// Disables a specific core interrupt source.
 #[inline]
-pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
+pub fn disable<I: CoreInterruptNumber>(interrupt: I) {
     // SAFETY: it is safe to disable an interrupt source
     unsafe { _clear(1 << interrupt.number()) };
 }
@@ -74,7 +74,7 @@ pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
 /// Enabling interrupts might break critical sections or other synchronization mechanisms.
 /// Ensure that this is called in a safe context where interrupts can be enabled.
 #[inline]
-pub unsafe fn enable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
+pub unsafe fn enable<I: CoreInterruptNumber>(interrupt: I) {
     unsafe { _set(1 << interrupt.number()) };
 }
 


### PR DESCRIPTION
This PR adds new methods and functions for the `mie` CSR. The idea is to use the `riscv_pac::CoreInterruptNumber` trait to allow enabling and disabling target-specific interrupt sources (i.e., extending our API to non-standard interrupt sources).

Closes #314 