### PR TITLE
`riscv`: Use `riscv_pac::CoreInterruptNumber` in `xip` registers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Cargo.lock
 target/
 
+.idea/
 .vscode/
 .DS_Store

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New methods and functions for dealing with pending interrupts in `mip` and `sip` registers
   using the `riscv_pac::CoreInterruptNumber` trait.
 - New `riscv::interrupt::is_interrupt_pending` function.
+- New `riscv::register::xip::clear_pending` atomic function for `mip` and `sip` registers.
+  This function is marked as `unsafe`, as its availability depends both on the target chip
+  and the target interrupt source.
 
 ### Changed
 
@@ -27,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Removed custom build script, as `cfg(riscv)` is no longer necessary.
+- All the fields of `Mip` and `Sip` CSR proxies are now read-only. This change is motivated
+  to avoid clearing unwanted interrupts triggered between CSR reads and CSR writes.
 
 ## [v0.14.0] - 2025-06-10
 

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - New convenience  `try_new` and `new` associated functions for `Mtvec` and `Stvec`.
 - New methods and functions for enabling core interrupts in the `mie` and `sie` registers
-  using the `riscv_pac::CoreInterrupt` trait.
+  using the `riscv_pac::CoreInterruptNumber` trait.
 - New `riscv::interrupt::{is_interrupt_enabled, disable_interrupt, enable_interrupt}` functions.
+- New methods and functions for dealing with pending interrupts in `mip` and `sip` registers
+  using the `riscv_pac::CoreInterruptNumber` trait.
+- New `riscv::interrupt::is_interrupt_pending` function.
 
 ### Changed
 

--- a/riscv/src/interrupt/machine.rs
+++ b/riscv/src/interrupt/machine.rs
@@ -1,6 +1,6 @@
 use crate::{
     interrupt::Trap,
-    register::{mcause, mepc, mie, mstatus},
+    register::{mcause, mepc, mie, mip, mstatus},
 };
 use riscv_pac::{
     result::{Error, Result},
@@ -121,6 +121,12 @@ pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
 #[inline]
 pub unsafe fn enable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
     mie::enable(interrupt);
+}
+
+/// Checks if a specific core interrupt source is pending in the current hart (machine mode).
+#[inline]
+pub fn is_interrupt_pending<I: CoreInterruptNumber>(interrupt: I) -> bool {
+    mip::read().is_pending(interrupt)
 }
 
 /// Disables interrupts globally in the current hart (machine mode).

--- a/riscv/src/interrupt/supervisor.rs
+++ b/riscv/src/interrupt/supervisor.rs
@@ -1,6 +1,6 @@
 use crate::{
     interrupt::Trap,
-    register::{scause, sepc, sie, sstatus},
+    register::{scause, sepc, sie, sip, sstatus},
 };
 use riscv_pac::{
     result::{Error, Result},
@@ -114,6 +114,12 @@ pub fn disable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
 #[inline]
 pub unsafe fn enable_interrupt<I: CoreInterruptNumber>(interrupt: I) {
     sie::enable(interrupt);
+}
+
+/// Checks if a specific core interrupt source is pending in the current hart (supervisor mode).
+#[inline]
+pub fn is_interrupt_pending<I: CoreInterruptNumber>(interrupt: I) -> bool {
+    sip::read().is_pending(interrupt)
 }
 
 /// Disables interrupts globally in the current hart (supervisor mode).

--- a/riscv/src/register/mip.rs
+++ b/riscv/src/register/mip.rs
@@ -1,15 +1,15 @@
 //! mip register
 
-use crate::bits::{bf_extract, bf_insert};
+use crate::bits::bf_extract;
 use riscv_pac::CoreInterruptNumber;
 
-read_write_csr! {
+read_only_csr! {
     /// `mip` register
     Mip: 0x344,
     mask: usize::MAX,
 }
 
-read_write_csr_field! {
+read_only_csr_field! {
     Mip,
     /// Supervisor Software Interrupt Pending
     ssoft: 1,
@@ -21,7 +21,7 @@ read_only_csr_field! {
     msoft: 3,
 }
 
-read_write_csr_field! {
+read_only_csr_field! {
     Mip,
     /// Supervisor Timer Interrupt Pending
     stimer: 5,
@@ -33,7 +33,7 @@ read_only_csr_field! {
     mtimer: 7,
 }
 
-read_write_csr_field! {
+read_only_csr_field! {
     Mip,
     /// Supervisor External Interrupt Pending
     sext: 9,
@@ -50,18 +50,6 @@ impl Mip {
     #[inline]
     pub fn is_pending<I: CoreInterruptNumber>(&self, interrupt: I) -> bool {
         bf_extract(self.bits, interrupt.number(), 1) != 0
-    }
-
-    /// Clear the pending state of a specific core interrupt source.
-    ///
-    /// # Safety
-    ///
-    /// Not all interrupt sources allow clearing of pending interrupts via the `mip` register.
-    /// Instead, it may be necessary to perform an alternative action to clear the interrupt.
-    /// Check the specification of your target chip for details.
-    #[inline]
-    pub unsafe fn clear_pending<I: CoreInterruptNumber>(&mut self, interrupt: I) {
-        self.bits = bf_insert(self.bits, interrupt.number(), 1, 0);
     }
 }
 
@@ -85,6 +73,7 @@ set_clear_csr!(
 /// Not all interrupt sources allow clearing of pending interrupts via the `mip` register.
 /// Instead, it may be necessary to perform an alternative action to clear the interrupt.
 /// Check the specification of your target chip for details.
+#[inline]
 pub unsafe fn clear_pending<I: CoreInterruptNumber>(interrupt: I) {
     _clear(1 << interrupt.number());
 }

--- a/riscv/src/register/sip.rs
+++ b/riscv/src/register/sip.rs
@@ -1,9 +1,12 @@
 //! sip register
 
+use crate::bits::{bf_extract, bf_insert};
+use riscv_pac::CoreInterruptNumber;
+
 read_write_csr! {
     /// sip register
     Sip: 0x144,
-    mask: 0x222,
+    mask: usize::MAX,
 }
 
 read_write_csr_field! {
@@ -24,12 +27,43 @@ read_only_csr_field! {
     sext: 9,
 }
 
+impl Sip {
+    /// Returns true when a given interrupt is pending.
+    #[inline]
+    pub fn is_pending<I: CoreInterruptNumber>(&self, interrupt: I) -> bool {
+        bf_extract(self.bits, interrupt.number(), 1) != 0
+    }
+
+    /// Clear the pending state of a specific core interrupt source.
+    ///
+    /// # Safety
+    ///
+    /// Not all interrupt sources allow clearing of pending interrupts via the `sip` register.
+    /// Instead, it may be necessary to perform an alternative action to clear the interrupt.
+    /// Check the specification of your target chip for details.
+    #[inline]
+    pub unsafe fn clear_pending<I: CoreInterruptNumber>(&mut self, interrupt: I) {
+        self.bits = bf_insert(self.bits, interrupt.number(), 1, 0);
+    }
+}
+
 set!(0x144);
 clear!(0x144);
 
 set_clear_csr!(
     /// Supervisor Software Interrupt Pending
     , set_ssoft, clear_ssoft, 1 << 1);
+
+/// Clear the pending state of a specific core interrupt source.
+///
+/// # Safety
+///
+/// Not all interrupt sources allow clearing of pending interrupts via the `sip` register.
+/// Instead, it may be necessary to perform an alternative action to clear the interrupt.
+/// Check the specification of your specific core for details.
+pub unsafe fn clear_pending<I: CoreInterruptNumber>(interrupt: I) {
+    _clear(1 << interrupt.number());
+}
 
 #[cfg(test)]
 mod tests {

--- a/riscv/src/register/sip.rs
+++ b/riscv/src/register/sip.rs
@@ -1,15 +1,15 @@
 //! sip register
 
-use crate::bits::{bf_extract, bf_insert};
+use crate::bits::bf_extract;
 use riscv_pac::CoreInterruptNumber;
 
-read_write_csr! {
+read_only_csr! {
     /// sip register
     Sip: 0x144,
     mask: usize::MAX,
 }
 
-read_write_csr_field! {
+read_only_csr_field! {
     Sip,
     /// Supervisor Software Interrupt Pending
     ssoft: 1,
@@ -33,18 +33,6 @@ impl Sip {
     pub fn is_pending<I: CoreInterruptNumber>(&self, interrupt: I) -> bool {
         bf_extract(self.bits, interrupt.number(), 1) != 0
     }
-
-    /// Clear the pending state of a specific core interrupt source.
-    ///
-    /// # Safety
-    ///
-    /// Not all interrupt sources allow clearing of pending interrupts via the `sip` register.
-    /// Instead, it may be necessary to perform an alternative action to clear the interrupt.
-    /// Check the specification of your target chip for details.
-    #[inline]
-    pub unsafe fn clear_pending<I: CoreInterruptNumber>(&mut self, interrupt: I) {
-        self.bits = bf_insert(self.bits, interrupt.number(), 1, 0);
-    }
 }
 
 set!(0x144);
@@ -61,6 +49,7 @@ set_clear_csr!(
 /// Not all interrupt sources allow clearing of pending interrupts via the `sip` register.
 /// Instead, it may be necessary to perform an alternative action to clear the interrupt.
 /// Check the specification of your specific core for details.
+#[inline]
 pub unsafe fn clear_pending<I: CoreInterruptNumber>(interrupt: I) {
     _clear(1 << interrupt.number());
 }


### PR DESCRIPTION
The methods for unpending interrupts via xip registers are marked as `unsafe`, as per the RISCV ISA specification:

> "Each individual bit in register mip may be writable or may be read-only. When bit i in mip is writable, a pending interrupt i can be cleared by writing 0 to this bit. If interrupt i can become pending but bit i in mip is read-only, the implementation must provide some other mechanism for clearing the pending interrupt.

Therefore, each platform may provide a safe abstraction of these functions for their target when applies.