### PR TITLE
Allow 64-bit Mcause::from_bits on rv64

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `cfg(any(target_arch = "riscv32", target_arch = "riscv64"))` instead of `cfg(riscv)`.
 - `riscv::pac_enum(unsafe CoreInterrupt)` now locates the vector table at the `.trap.vector`
   section instead of `.trap`.
+- Allow all bits to be set in Mcause::from_bits on 64-bit targets.
 
 ### Removed
 

--- a/riscv/src/register/mcause.rs
+++ b/riscv/src/register/mcause.rs
@@ -5,7 +5,7 @@ pub use crate::interrupt::Trap;
 read_only_csr! {
     /// `mcause` register
     Mcause: 0x342,
-    mask: 0xffff_ffff,
+    mask: usize::MAX,
 }
 
 #[cfg(target_arch = "riscv32")]


### PR DESCRIPTION
Set the mcause mask to `!0u64` on rv64 targets.

Fixes #333