### PR TITLE
Optionally implement `defmt::Format`

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `.uninit` section to the linker file. Due to its similarities with `.bss`, the
   linker will place this new section in `REGION_BSS`.
 - Additional feature `no-xie-xip` to work on chips without the XIE and XIP CSRs (e.g. ESP32-C2, ESP32-C3)
+- Additional feature `defmt` which will implement `defmt::Format` on certain types
 
 ### Changed
 

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -28,6 +28,8 @@ riscv = { path = "../riscv", version = "0.14.0" }
 riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
 riscv-rt-macros = { path = "macros", version = "0.5.0" }
 
+defmt = { version = "1.0.1", optional = true }
+
 [dev-dependencies]
 panic-halt = "1.0.0"
 
@@ -43,3 +45,4 @@ no-exceptions = []
 no-xie-xip = []
 device = []
 memory = []
+defmt = ["dep:defmt"]

--- a/riscv-rt/src/interrupts.rs
+++ b/riscv-rt/src/interrupts.rs
@@ -20,6 +20,7 @@
 // In vectored mode, we also must provide a vector table
 #[riscv::pac_enum(unsafe CoreInterruptNumber)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum Interrupt {
     SupervisorSoft = 1,
     MachineSoft = 3,

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -707,6 +707,7 @@ pub unsafe extern "Rust" fn setup_interrupts() {
 /// Registers saved in trap handler
 #[repr(C)]
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TrapFrame {
     /// `x1`: return address, stores the address to return to after a function call or interrupt.
     pub ra: usize,


### PR DESCRIPTION
Not a huge thing but since `Debug` is already implemented on these two types, having `defmt::Format` would be useful (at least for us and at least for `TrapFrame` ).

Given `defmt` is 1.0 this shouldn't be a problem, I guess. Let me know if you want something changed here or if you in general dislike the optional dependency.
