### PR TITLE
Allow `extern "C"`

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `a2` is preserved in `a5`, as there are only two callee-saved registers.
   New documentation of startup functions (`_mp_hook` and `__pre_init`) now provide
   additional implementation guidelines to ensure a correct behavior of the runtime.
+- Allow `extern "C"` functions for exceptions, core-interrupts and external-interrupts.
 
 ### Removed
 

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -727,7 +727,6 @@ impl RiscvPacItem {
                 }) if name.value() == "C" => true,
                 _ => false,
             }
-            && f.sig.unsafety.is_none()
             && f.sig.generics.params.is_empty()
             && f.sig.generics.where_clause.is_none()
             && f.sig.variadic.is_none()

--- a/tests-trybuild/tests/riscv-rt/core_interrupt/fail_signatures.stderr
+++ b/tests-trybuild/tests/riscv-rt/core_interrupt/fail_signatures.stderr
@@ -1,16 +1,16 @@
-error: `#[core_interrupt]` function must have signature `[unsafe] fn() [-> !]`
+error: `#[core_interrupt]` function must have signature `[unsafe] [extern "C"] fn() [-> !]`
  --> tests/riscv-rt/core_interrupt/fail_signatures.rs:2:1
   |
 2 | fn my_interrupt(code: usize) {}
   | ^^
 
-error: `#[core_interrupt]` function must have signature `[unsafe] fn() [-> !]`
+error: `#[core_interrupt]` function must have signature `[unsafe] [extern "C"] fn() [-> !]`
  --> tests/riscv-rt/core_interrupt/fail_signatures.rs:5:1
   |
 5 | fn my_other_interrupt() -> usize {}
   | ^^
 
-error: `#[core_interrupt]` function must have signature `[unsafe] fn() [-> !]`
+error: `#[core_interrupt]` function must have signature `[unsafe] [extern "C"] fn() [-> !]`
  --> tests/riscv-rt/core_interrupt/fail_signatures.rs:8:1
   |
 8 | async fn my_async_interrupt() {}

--- a/tests-trybuild/tests/riscv-rt/exception/fail_signatures.stderr
+++ b/tests-trybuild/tests/riscv-rt/exception/fail_signatures.stderr
@@ -1,16 +1,16 @@
-error: `#[exception]` function must have signature `[unsafe] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
+error: `#[exception]` function must have signature `[unsafe] [extern "C"] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
  --> tests/riscv-rt/exception/fail_signatures.rs:2:1
   |
 2 | fn my_exception(code: usize) {}
   | ^^
 
-error: `#[exception]` function must have signature `[unsafe] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
+error: `#[exception]` function must have signature `[unsafe] [extern "C"] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
  --> tests/riscv-rt/exception/fail_signatures.rs:5:1
   |
 5 | fn my_other_exception(trap_frame: &riscv_rt::TrapFrame, code: usize) {}
   | ^^
 
-error: `#[exception]` function must have signature `[unsafe] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
+error: `#[exception]` function must have signature `[unsafe] [extern "C"] fn([&[mut] riscv_rt::TrapFrame]) [-> !]`
  --> tests/riscv-rt/exception/fail_signatures.rs:8:1
   |
 8 | async fn my_async_exception(trap_frame: &riscv_rt::TrapFrame, code: usize) {}

--- a/tests-trybuild/tests/riscv-rt/external_interrupt/fail_signatures.stderr
+++ b/tests-trybuild/tests/riscv-rt/external_interrupt/fail_signatures.stderr
@@ -1,16 +1,16 @@
-error: `#[external_interrupt]` function must have signature `[unsafe] fn() [-> !]`
+error: `#[external_interrupt]` function must have signature `[unsafe] [extern "C"] fn() [-> !]`
   --> tests/riscv-rt/external_interrupt/fail_signatures.rs:31:1
    |
 31 | fn my_interrupt() -> usize {}
    | ^^
 
-error: `#[external_interrupt]` function must have signature `[unsafe] fn() [-> !]`
+error: `#[external_interrupt]` function must have signature `[unsafe] [extern "C"] fn() [-> !]`
   --> tests/riscv-rt/external_interrupt/fail_signatures.rs:34:1
    |
 34 | fn my_other_interrupt(code: usize) -> usize {}
    | ^^
 
-error: `#[external_interrupt]` function must have signature `[unsafe] fn() [-> !]`
+error: `#[external_interrupt]` function must have signature `[unsafe] [extern "C"] fn() [-> !]`
   --> tests/riscv-rt/external_interrupt/fail_signatures.rs:37:1
    |
 37 | async fn my_async_interrupt(code: usize) -> usize {}


### PR DESCRIPTION
This allows `extern "C"` functions for exception, core_interrupt and external_interrupt.

To the extend its used here, C-abi and Rust-abi is same.

The real motivation however is to allow us to use naked-functions on stable (it's not stable for Rust-abi)
