### PR TITLE
Prepare for new `riscv` releases

### DIFF
--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.4.0] - 2025-09-04
+
 ### Added
 
 - Constant methods to access to PLIC and ACLINT registers for HART 0.
   These new methods are especially convenient for single-HART targets.
+
+### Removed
+
+- Removed `riscv` reexport.
 
 ## [v0.3.0] - 2025-06-10
 

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-peripheral"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.75"
 repository = "https://github.com/rust-embedded/riscv"
@@ -16,7 +16,7 @@ license = "ISC"
 [dependencies]
 embedded-hal = "1.0.0"
 paste = "1.0"
-riscv = { path = "../riscv", version = "0.14.0" }
+riscv = { path = "../riscv", version = "0.15.0" }
 riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
 
 [package.metadata.docs.rs]

--- a/riscv-peripheral/src/lib.rs
+++ b/riscv-peripheral/src/lib.rs
@@ -3,7 +3,6 @@
 #![deny(missing_docs)]
 #![no_std]
 
-pub use riscv; // re-export riscv crate to allow macros to use it
 pub use riscv_pac::result; // re-export the result module
 
 pub mod common; // common definitions for all peripherals

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.16.0] - 2025-09-04
+
 ### Added
 
 - New `post-init` feature to run a Rust `__post_init` function before jumping to `main`.
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Additional feature `no-xie-xip` to work on chips without the XIE and XIP CSRs (e.g. ESP32-C2, ESP32-C3)
 - Additional feature `defmt` which will implement `defmt::Format` on certain types
 - Additional feature `pre-default-start-trap` to execute custom code before `_default_start_trap`
+
 ### Changed
 
 - `main` function no longer needs to be close to `_start`. A linker script may copy

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.15.0"
+version = "0.16.0"
 rust-version = "1.67"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
@@ -24,9 +24,9 @@ targets = [
 riscv-target-parser = { path = "../riscv-target-parser", version = "0.1.2" }
 
 [dependencies]
-riscv = { path = "../riscv", version = "0.14.0" }
+riscv = { path = "../riscv", version = "0.15.0" }
 riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
-riscv-rt-macros = { path = "macros", version = "0.5.0" }
+riscv-rt-macros = { path = "macros", version = "0.6.0" }
 
 defmt = { version = "1.0.1", optional = true }
 

--- a/riscv-rt/macros/Cargo.toml
+++ b/riscv-rt/macros/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["riscv", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "riscv-rt-macros"
 repository = "https://github.com/rust-embedded/riscv"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/riscv-semihosting/CHANGELOG.md
+++ b/riscv-semihosting/CHANGELOG.md
@@ -5,8 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.1] - 2025-09-04
+
 ### Changed
 
+- Update riscv to 0.15.0.
 - Use `cfg(any(target_arch = "riscv32", target_arch = "riscv64"))` instead of `cfg(riscv)`.
 
 ### Removed

--- a/riscv-semihosting/Cargo.toml
+++ b/riscv-semihosting/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "riscv-semihosting"
 readme = "README.md"
 repository = "https://github.com/riscv-rust/riscv"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.67"
 
@@ -24,4 +24,4 @@ default = ["jlink-quirks"]
 
 [dependencies]
 critical-section = "1.2.0"
-riscv = { path = "../riscv", version = "0.14.0" }
+riscv = { path = "../riscv", version = "0.15.0" }

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.15.0] - 2025-09-04
+
 ### Added
 
 - New convenience  `try_new` and `new` associated functions for `Mtvec` and `Stvec`.

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.67"
 repository = "https://github.com/rust-embedded/riscv"
@@ -28,5 +28,5 @@ critical-section-single-hart = ["critical-section/restore-state-bool"]
 critical-section = "1.2.0"
 embedded-hal = "1.0.0"
 riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
-riscv-macros = { path = "macros", version = "0.2.0", optional = true }
+riscv-macros = { path = "macros", version = "0.3.0", optional = true }
 paste = "1.0.15"

--- a/riscv/macros/Cargo.toml
+++ b/riscv/macros/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["riscv", "register", "peripheral"]
 license = "MIT OR Apache-2.0"
 name = "riscv-macros"
 repository = "https://github.com/rust-embedded/riscv"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Closes #339 

Closes #239 (no longer needed for ESP32 crates)