### PR TITLE
riscv: add the `miselect` CSR

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `miselect` CSR
+
 ## [v0.15.0] - 2025-09-08
 
 ### Added

--- a/riscv/src/register.rs
+++ b/riscv/src/register.rs
@@ -117,6 +117,9 @@ pub mod mseccfg;
 #[cfg(any(test, target_arch = "riscv32"))]
 pub mod mseccfgh;
 
+// Machine indirect access
+pub mod miselect;
+
 #[cfg(test)]
 mod tests;
 

--- a/riscv/src/register/miselect.rs
+++ b/riscv/src/register/miselect.rs
@@ -45,3 +45,20 @@ read_write_csr_field! {
     /// and the relevant `mireg*` value.
     value: [0:62],
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        (0..=usize::BITS)
+            .map(|r| ((1u128 << r) - 1) as usize)
+            .for_each(|bits| {
+                let mut miselect = Miselect::from_bits(bits);
+
+                test_csr_field!(miselect, is_custom);
+                test_csr_field!(miselect, value: [0, usize::BITS - 2], 0);
+            });
+    }
+}

--- a/riscv/src/register/miselect.rs
+++ b/riscv/src/register/miselect.rs
@@ -1,0 +1,47 @@
+//! `miselect` register.
+
+const MASK: usize = usize::MAX;
+
+read_write_csr! {
+    /// `miselect` register.
+    Miselect: 0x350,
+    mask: MASK,
+}
+
+#[cfg(target_arch = "riscv32")]
+read_write_csr_field! {
+    Miselect,
+    /// Returns whether `miselect` is for custom use of indirect CSRs.
+    is_custom: 31,
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+read_write_csr_field! {
+    Miselect,
+    /// Returns whether `miselect` is for custom use of indirect CSRs.
+    is_custom: 63,
+}
+
+#[cfg(target_arch = "riscv32")]
+read_write_csr_field! {
+    Miselect,
+    /// Gets the value stored in the `miselect` CSR.
+    ///
+    /// # Note
+    ///
+    /// The semantics of the value depend on the extension for the referenced CSR,
+    /// and the relevant `mireg*` value.
+    value: [0:30],
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+read_write_csr_field! {
+    Miselect,
+    /// Gets the value stored in the `miselect` CSR.
+    ///
+    /// # Note
+    ///
+    /// The semantics of the value depend on the extension for the referenced CSR,
+    /// and the relevant `mireg*` value.
+    value: [0:62],
+}


### PR DESCRIPTION
Adds the `miselect` register for selecting an indirect CSR according to the `Smcsrind` extension.

Related: #1, #226