### PR TITLE
Add `rt` feature gate to riscv::pac_enum

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `miselect` CSR
 - Improved assembly macro handling in asm.rs
 
+### Fixed
+
+- Fixed `riscv::pac_enum` macro. Now, it only generates `riscv-rt`-related code if feature `rt`
+  is enabled in the caller crate (presumably, a PAC).
+
 ## [v0.15.0] - 2025-09-08
 
 ### Added

--- a/riscv/macros/src/lib.rs
+++ b/riscv/macros/src/lib.rs
@@ -280,7 +280,7 @@ impl PacEnumItem {
         };
         let mut asm = format!(
             r#"
-#[cfg(all(feature = "v-trap", any(target_arch = "riscv32", target_arch = "riscv64")))]
+#[cfg(all(feature = "rt", feature = "v-trap", any(target_arch = "riscv32", target_arch = "riscv64")))]
 core::arch::global_asm!("
     .section .trap.vector, \"ax\"
     .global _vector_table
@@ -366,8 +366,8 @@ core::arch::global_asm!("
             let handlers = self.handlers(&trap_config);
             let interrupt_array = self.handlers_array();
             let cfg_v_trap = match is_core_interrupt {
-                true => Some(quote!(#[cfg(not(feature = "v-trap"))])),
-                false => None,
+                true => quote!(#[cfg(all(feature = "rt", not(feature = "v-trap")))]),
+                false => quote!(#[cfg(feature = "rt")]),
             };
 
             // Push the interrupt handler functions and the interrupt array


### PR DESCRIPTION
An alternative to #345 

It presents way fewer changes, but now we expect caller crates of the `pac_enum` macro to include two features:

- `rt`
- `v-trap`

I personally prefer this approach, but let me know your opinion.

Related issues: https://github.com/rust-embedded/svd2rust/issues/948