### PR TITLE
Add mtopi CSR

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `mtopi` CSR support for the RISC-V Advanced Interrupt Architecture extension.
 - Added DCSR (Debug Control and Status Register) CSR support for the RISC-V
 - Add `miselect` CSR
 - Improved assembly macro handling in asm.rs

--- a/riscv/src/register.rs
+++ b/riscv/src/register.rs
@@ -89,6 +89,7 @@ pub mod mepc;
 pub mod mip;
 pub mod mscratch;
 pub mod mtinst;
+pub mod mtopi;
 pub mod mtval;
 pub mod mtval2;
 

--- a/riscv/src/register/mtopi.rs
+++ b/riscv/src/register/mtopi.rs
@@ -1,0 +1,111 @@
+//! mtopi register — Machine Top Priority Interrupt (0x7C0)
+//!
+//! Provides information about the highest-priority pending interrupt when AIA (Advanced Interrupt Architecture) is supported.
+//! This CSR is part of the RISC-V Advanced Interrupt Architecture extension and allows software to quickly
+//! identify the most important pending interrupt without scanning through multiple interrupt pending registers.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use riscv::register::mtopi;
+//!
+//! // Read the machine top priority interrupt register
+//! let mtopi_val = mtopi::read();
+//!
+//! if mtopi_val.has_interrupt() {
+//!     let interrupt_id = mtopi_val.interrupt_id();
+//!     let priority = mtopi_val.priority();
+//!     println!("Highest priority interrupt: ID={}, Priority={}", interrupt_id, priority);
+//! } else {
+//!     println!("No interrupts pending");
+//! }
+//! ```
+
+read_only_csr! {
+    /// Machine Top Priority Interrupt Register
+    Mtopi: 0x7C0,
+    mask: usize::MAX,
+}
+
+read_only_csr_field! {
+    Mtopi,
+    /// Interrupt ID (bits 16..27)
+    ///
+    /// Identifies the specific interrupt source. A value of 0 indicates no interrupt is pending.
+    /// Non-zero values correspond to specific interrupt sources as defined by the interrupt controller.
+    iid: [16:27],
+}
+
+read_only_csr_field! {
+    Mtopi,
+    /// Interrupt Priority ID (bits 0..7)
+    ///
+    /// Represents the priority level of the pending interrupt.
+    /// Higher numerical values indicate higher priority interrupts.
+    ipid: [0:7],
+}
+
+impl Mtopi {
+    /// Returns true if there is a valid interrupt pending
+    ///
+    /// When this returns true, both `interrupt_id()` and `priority()` will return meaningful values.
+    #[inline]
+    pub fn has_interrupt(&self) -> bool {
+        self.iid() != 0
+    }
+
+    /// Returns the interrupt priority, with higher values indicating higher priority
+    ///
+    /// This value is only meaningful when `has_interrupt()` returns true.
+    #[inline]
+    pub fn priority(&self) -> usize {
+        self.ipid()
+    }
+
+    /// Returns the interrupt identifier
+    ///
+    /// A value of 0 indicates no interrupt is pending. Non-zero values identify
+    /// specific interrupt sources as defined by the interrupt controller configuration.
+    #[inline]
+    pub fn interrupt_id(&self) -> usize {
+        self.iid()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mtopi_fields() {
+        let mtopi = Mtopi::from_bits(0);
+
+        assert_eq!(mtopi.iid(), 0);
+        assert_eq!(mtopi.ipid(), 0);
+        assert!(!mtopi.has_interrupt());
+        assert_eq!(mtopi.priority(), 0);
+        assert_eq!(mtopi.interrupt_id(), 0);
+
+        // Test with some interrupt pending (IID = 11, IPID = 5)
+        let mtopi = Mtopi::from_bits((11 << 16) | 5);
+
+        assert_eq!(mtopi.iid(), 11);
+        assert_eq!(mtopi.ipid(), 5);
+        assert!(mtopi.has_interrupt());
+        assert_eq!(mtopi.priority(), 5);
+        assert_eq!(mtopi.interrupt_id(), 11);
+
+        // Test maximum values
+        let mtopi = Mtopi::from_bits((0xFFF << 16) | 0xFF);
+
+        assert_eq!(mtopi.iid(), 0xFFF);
+        assert_eq!(mtopi.ipid(), 0xFF);
+        assert!(mtopi.has_interrupt());
+    }
+
+    #[test]
+    fn test_mtopi_bitmask() {
+        let mtopi = Mtopi::from_bits(usize::MAX);
+        assert_eq!(mtopi.bits(), usize::MAX);
+    }
+}


### PR DESCRIPTION
This PR adds support for the `mtopi` (Machine Top Priority Interrupt) CSR, which is part of the RISC-V Advanced Interrupt Architecture (AIA) extension.

**Changes:**
- Add `mtopi.rs` register implementation at address 0x7C0
- Export mtopi module in `register.rs`
- Read-only CSR with proper bit field definitions:
  - `iid` (Interrupt ID): bits 16-27 
  - `ipid` (Interrupt Priority ID): bits 0-7
- Convenience methods for interrupt detection and priority handling

**Features:**
- Memory-safe read-only access
- Comprehensive documentation with usage examples
- Full test coverage
- Follows existing CSR implementation patterns

**Testing:**
- All existing tests continue to pass
- New tests cover bit field extraction and edge cases
- Documentation examples compile successfully

**AI Assistance:**
Parts of the explanation and understanding of the mtopi CSR were assisted using an AI tool to summarize its behavior in the context of the RISC-V Advanced Interrupt Architecture (AIA). All code and implementation decisions were written and verified manually. NO CODES WERE GENERATED WITH THE HELP OF AI.