### PR TITLE
Fix: Don't crash when target-feature=+relax is given

### DIFF
--- a/riscv-target-parser/CHANGELOG.md
+++ b/riscv-target-parser/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip the 'relax' target feature when parsing extensions
+
 ## [v0.1.2] - 2025-06-10
 
 ### Fixed


### PR DESCRIPTION
This feature is a bit unusual in that it does not refer to actual hardware features, but is rather a target-specific linker feature. This PR simply skips this feature when building `RiscvTarget`, since from my understanding, it is irrelevant here.

See also https://github.com/rust-lang/rust/pull/109860