### PR TITLE
Publish `riscv-target-parser` patch

### DIFF
--- a/riscv-target-parser/CHANGELOG.md
+++ b/riscv-target-parser/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.3] - 2025-09-29
+
 ### Fixed
 
 - Skip the 'relax' target feature when parsing extensions

--- a/riscv-target-parser/Cargo.toml
+++ b/riscv-target-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-target-parser"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.61"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]


### PR DESCRIPTION
This PR prepares to publish a new version of `riscv-target-parser` with the changes on #349 

The idea is publishing it ASAP and yanking its previous version.