### PR TITLE
`riscv`: Run tests on CI

### DIFF
--- a/.github/workflows/riscv.yaml
+++ b/.github/workflows/riscv.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Build (all features)
       run: cargo build --package riscv --target ${{ matrix.target }} --all-features
 
-  # On MacOS, Ubuntu, and Windows, we at least make sure that the crate builds and links.
+  # On MacOS, Ubuntu, and Windows, we run tests.
   build-others:
     strategy:
       matrix:
@@ -49,10 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build (no features)
-        run: cargo build --package riscv
-      - name: Build (all features)
-        run: cargo build --package riscv --all-features
+      - name: Test (no features)
+        run: cargo test --package riscv
+      - name: Test (all features)
+        run: cargo test --package riscv --all-features
 
   # Job to check that all the builds succeeded
   build-check:


### PR DESCRIPTION
While reviewing #347 , I noticed that a test should have failed but CI didn't show any issue. It looks like our current CI does not run `riscv` tests, as it only checks that it can compile. This PR should fix this.