### PR TITLE
`riscv-rt`: fix stack allocation for targets without M extension

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump MSRV to 1.68 for latest syn 2.0 release
 - Adapted to new `riscv` version.
 
+### Fixed
+
+- Fix stack allocation algorithm for multi-core targets without M extension
+
 ## [v0.16.0] - 2025-09-08
 
 ### Added

--- a/riscv-rt/src/asm.rs
+++ b/riscv-rt/src/asm.rs
@@ -105,13 +105,13 @@ _abs_start:
 #[cfg(not(feature = "single-hart"))]
 {
     "mv t2, a0
-    lui t0, %hi(_hart_stack_size)
-    add t0, t0, %lo(_hart_stack_size)",
+    lui t1, %hi(_hart_stack_size)
+    add t1, t1, %lo(_hart_stack_size)",
     #[cfg(riscvm)]
-    "mul t0, t2, t0",
+    "mul t0, t2, t1",
     #[cfg(not(riscvm))]
-    "beqz t2, 2f  // skip if hart ID is 0
-    mv t1, t0
+    "mv t0, x0
+    beqz t2, 2f  // skip if hart ID is 0
 1:
     add t0, t0, t1
     addi t2, t2, -1


### PR DESCRIPTION
Fixes #362 