### PR TITLE
`riscv-macros`: use fully qualified paths

### DIFF
--- a/riscv-macros/CHANGELOG.md
+++ b/riscv-macros/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Use fully qualified paths in generated code (i.e., `::riscv` instead of `riscv`)
 - Moved from `riscv/macros/` to `riscv-macros/`
 - Now, `riscv::pac_enum` macro only includes trap-related code if `rt` or `rt-v-trap` features are enabled.
 

--- a/riscv-macros/src/lib.rs
+++ b/riscv-macros/src/lib.rs
@@ -339,7 +339,7 @@ core::arch::global_asm!("
 
         // Push the trait implementation
         res.push(quote! {
-            unsafe impl riscv::#trait_name for #name {
+            unsafe impl ::riscv::#trait_name for #name {
                 const #const_name: usize = #max_discriminant;
 
                 #[inline]
@@ -348,17 +348,17 @@ core::arch::global_asm!("
                 }
 
                 #[inline]
-                fn from_number(number: usize) -> riscv::result::Result<Self> {
+                fn from_number(number: usize) -> ::riscv::result::Result<Self> {
                     match number {
                         #(#valid_matches,)*
-                        _ => Err(riscv::result::Error::InvalidVariant(number)),
+                        _ => Err(::riscv::result::Error::InvalidVariant(number)),
                     }
                 }
             }
         });
 
         if let Some(marker_trait_name) = attr.marker_trait_name() {
-            res.push(quote! { unsafe impl riscv::#marker_trait_name for #name {} });
+            res.push(quote! { unsafe impl ::riscv::#marker_trait_name for #name {} });
         }
 
         #[cfg(feature = "rt")]


### PR DESCRIPTION
This is part of the work for improving the procedural macros used in this repo.