### PR TITLE
Use `riscv-types` instead of `riscv-pac`

### DIFF
--- a/.github/workflows/riscv-peripheral.yaml
+++ b/.github/workflows/riscv-peripheral.yaml
@@ -11,8 +11,8 @@ jobs:
   build-riscv:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.75.0
-        toolchain: [ stable, nightly, 1.75.0 ]
+        # All generated code should be running on stable now, MRSV is 1.81.0
+        toolchain: [ stable, nightly, 1.81.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf

--- a/.github/workflows/riscv-rt.yaml
+++ b/.github/workflows/riscv-rt.yaml
@@ -10,8 +10,8 @@ jobs:
   build-riscv:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.68.0
-        toolchain: [ stable, nightly, 1.68.0 ]
+        # All generated code should be running on stable now, MRSV is 1.81.0
+        toolchain: [ stable, nightly, 1.81.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32im-unknown-none-elf
@@ -27,11 +27,6 @@ jobs:
           # Nightly is only for reference and allowed to fail
           - toolchain: nightly
             experimental: true
-        exclude:
-          - toolchain: 1.68.0
-            target: riscv32im-unknown-none-elf
-          - toolchain: 1.68.0
-            target: riscv32imafc-unknown-none-elf
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental || false }}
     steps:

--- a/.github/workflows/riscv.yaml
+++ b/.github/workflows/riscv.yaml
@@ -11,8 +11,8 @@ jobs:
   build-riscv:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.68.0
-        toolchain: [ stable, nightly, 1.68.0 ]
+        # All generated code should be running on stable now, MRSV is 1.81.0
+        toolchain: [ stable, nightly, 1.81.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32imc-unknown-none-elf

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,8 +20,8 @@ jobs:
   run-build:
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.68.0
-        toolchain: [ stable, nightly, 1.68.0 ]
+        # All generated code should be running on stable now, MRSV is 1.81.0
+        toolchain: [ stable, nightly, 1.81.0 ]
         target:
           - riscv32i-unknown-none-elf
           - riscv32im-unknown-none-elf
@@ -36,11 +36,6 @@ jobs:
           # Nightly is only for reference and allowed to fail
           - toolchain: nightly
             experimental: true
-        exclude:
-          - toolchain: 1.68.0
-            target: riscv32im-unknown-none-elf
-          - toolchain: 1.68.0
-            target: riscv32imafc-unknown-none-elf
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental || false }}
     steps:

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This repository contains various crates useful for writing Rust programs on RISC-V microcontrollers:
 
 * [`riscv`]: CPU registers access and intrinsics
-* [`riscv-pac`]: Common traits to be implemented by RISC-V PACs
 * [`riscv-peripheral`]: Interfaces for standard RISC-V peripherals
 * [`riscv-rt`]: Startup code and interrupt handling
 * [`riscv-semihosting`]: Semihosting for RISC-V processors
 * [`riscv-target-parser`]: Utility crate for parsing RISC-V targets in build scripts
+* [`riscv-types`]: Common traits to be implemented by RISC-V PACs
 
 This project is developed and maintained by the [RISC-V team][team].
 
@@ -24,7 +24,7 @@ Conduct][CoC], the maintainer of this crate, the [RISC-V team][team], promises
 to intervene to uphold that code of conduct.
 
 [`riscv`]: https://crates.io/crates/riscv
-[`riscv-pac`]: https://crates.io/crates/riscv-pac
+[`riscv-types`]: https://crates.io/crates/riscv-types
 [`riscv-peripheral`]: https://crates.io/crates/riscv-peripheral
 [`riscv-rt`]: https://crates.io/crates/riscv-rt
 [`riscv-semihosting`]: https://crates.io/crates/riscv-semihosting

--- a/riscv-pac/CHANGELOG.md
+++ b/riscv-pac/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- This crate has been deprecated. Use `riscv-types` instead.
 - Updated the license to `MIT or Apache-2.0`
 
 ## [v0.2.0] - 2024-10-19

--- a/riscv-pac/Cargo.toml
+++ b/riscv-pac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-pac"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.60"
 repository = "https://github.com/rust-embedded/riscv"

--- a/riscv-pac/README.md
+++ b/riscv-pac/README.md
@@ -1,6 +1,10 @@
 [![crates.io](https://img.shields.io/crates/d/riscv-pac.svg)](https://crates.io/crates/riscv-pac)
 [![crates.io](https://img.shields.io/crates/v/riscv-pac.svg)](https://crates.io/crates/riscv-pac)
 
+# Deprecation notice
+
+This crate has been deprecated. Use [`riscv-types`](https://crates.io/crates/riscv-types) instead.
+
 # `riscv-pac`
 
 > Target-specific traits to be implemented by PACs

--- a/riscv-pac/src/lib.rs
+++ b/riscv-pac/src/lib.rs
@@ -1,3 +1,7 @@
+//! # Deprecation notice
+//!
+//! This crate has been deprecated. Use [`riscv-types`](https://crates.io/crates/riscv-types) instead.
+
 #![no_std]
 
 pub mod result;

--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Bump MSRV to 1.81 due to `riscv`
 - Update license to `MIT or Apache-2.0`
 
 ### Fixed

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -2,7 +2,7 @@
 name = "riscv-peripheral"
 version = "0.4.0"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
@@ -17,7 +17,6 @@ license = "MIT OR Apache-2.0"
 embedded-hal = "1.0.0"
 paste = "1.0"
 riscv = { path = "../riscv", version = "0.15.0" }
-riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/riscv-peripheral/README.md
+++ b/riscv-peripheral/README.md
@@ -11,12 +11,12 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.75 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.81 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License
 
-Copyright 2023-2024 [RISC-V team][team]
+Copyright 2023-2025 [RISC-V team][team]
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice

--- a/riscv-peripheral/src/aclint.rs
+++ b/riscv-peripheral/src/aclint.rs
@@ -7,7 +7,7 @@ pub mod mswi;
 pub mod mtimer;
 pub mod sswi;
 
-pub use riscv_pac::HartIdNumber; // re-export useful riscv-pac traits
+pub use riscv::HartIdNumber; // re-export useful riscv-types traits
 
 /// Trait for a CLINT peripheral.
 ///

--- a/riscv-peripheral/src/lib.rs
+++ b/riscv-peripheral/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs)]
 #![no_std]
 
-pub use riscv_pac::result; // re-export the result module
+pub use riscv::result; // re-export the result module
 
 pub mod common; // common definitions for all peripherals
 pub mod hal; // trait implementations for embedded-hal

--- a/riscv-peripheral/src/macros.rs
+++ b/riscv-peripheral/src/macros.rs
@@ -31,7 +31,7 @@ pub use paste::paste;
 /// ## Base address and per-HART mtimecmp registers, private `fn new()` function
 ///
 /// ```
-/// use riscv_pac::result::{Error, Result};
+/// use riscv::result::{Error, Result};
 ///
 /// /// HART IDs for the target CLINT peripheral
 /// #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -142,7 +142,7 @@ macro_rules! clint_codegen {
 /// ## Base address and per-HART context proxies, private `fn new()` function
 ///
 /// ```
-/// use riscv_pac::result::{Error, Result};
+/// use riscv::result::{Error, Result};
 ///
 /// /// HART IDs for the target CLINT peripheral
 /// #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/riscv-peripheral/src/plic.rs
+++ b/riscv-peripheral/src/plic.rs
@@ -200,7 +200,7 @@ impl<P: Plic> CTX<P> {
 #[cfg(test)]
 pub(crate) mod test {
     use crate::test::HartId;
-    use riscv_pac::HartIdNumber;
+    use riscv::HartIdNumber;
 
     #[allow(dead_code)]
     #[test]

--- a/riscv-peripheral/src/plic.rs
+++ b/riscv-peripheral/src/plic.rs
@@ -8,8 +8,8 @@ pub mod pendings;
 pub mod priorities;
 pub mod threshold;
 
-// re-export useful riscv-pac traits
-pub use riscv_pac::{HartIdNumber, InterruptNumber, PriorityNumber};
+// re-export useful riscv-types traits
+pub use riscv::{HartIdNumber, InterruptNumber, PriorityNumber};
 
 use riscv::register::{mhartid, mie, mip};
 

--- a/riscv-peripheral/src/plic/claim.rs
+++ b/riscv-peripheral/src/plic/claim.rs
@@ -1,7 +1,7 @@
 //! Interrupt claim/complete register
 
 use crate::common::unsafe_peripheral;
-use riscv_pac::ExternalInterruptNumber;
+use riscv::ExternalInterruptNumber;
 
 unsafe_peripheral!(CLAIM, u32, RW);
 

--- a/riscv-peripheral/src/plic/claim.rs
+++ b/riscv-peripheral/src/plic/claim.rs
@@ -32,7 +32,7 @@ impl CLAIM {
 mod test {
     use super::*;
     use crate::test::Interrupt;
-    use riscv_pac::InterruptNumber;
+    use riscv::InterruptNumber;
 
     #[test]
     fn test_claim() {

--- a/riscv-peripheral/src/plic/enables.rs
+++ b/riscv-peripheral/src/plic/enables.rs
@@ -1,7 +1,7 @@
 //! Interrupt enables register of a PLIC context.
 
 use crate::common::{Reg, RW};
-use riscv_pac::ExternalInterruptNumber;
+use riscv::ExternalInterruptNumber;
 
 /// Enables register of a PLIC context.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/riscv-peripheral/src/plic/pendings.rs
+++ b/riscv-peripheral/src/plic/pendings.rs
@@ -1,7 +1,7 @@
 //! Interrupt pending bits register.
 
 use crate::common::{Reg, RO};
-use riscv_pac::ExternalInterruptNumber;
+use riscv::ExternalInterruptNumber;
 
 /// Interrupts pending bits register.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/riscv-peripheral/src/plic/priorities.rs
+++ b/riscv-peripheral/src/plic/priorities.rs
@@ -71,7 +71,7 @@ impl PRIORITIES {
 mod test {
     use super::*;
     use crate::test::{Interrupt, Priority};
-    use riscv_pac::InterruptNumber;
+    use riscv::InterruptNumber;
 
     #[test]
     fn test_priorities() {

--- a/riscv-peripheral/src/plic/priorities.rs
+++ b/riscv-peripheral/src/plic/priorities.rs
@@ -1,7 +1,7 @@
 //! Interrupts Priorities register.
 
 use crate::common::{Reg, RW};
-use riscv_pac::{ExternalInterruptNumber, PriorityNumber};
+use riscv::{ExternalInterruptNumber, PriorityNumber};
 
 /// Interrupts priorities register.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Add features to documentation that were missing and fix `cargo doc` errors.
+- Bump MSRV to 1.81 due to `riscv-types`
+- Use `riscv-types` instead of `riscv-pac`
 - Update license to `MIT or Apache-2.0`
 - Fix clippy warnings in riscv_rt_macros::strip_type_path
 - Bump MSRV to 1.68 for latest syn 2.0 release

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "riscv-rt"
 version = "0.16.0"
-rust-version = "1.68"
+rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]
@@ -25,7 +25,7 @@ riscv-target-parser = { path = "../riscv-target-parser", version = "0.1.2" }
 
 [dependencies]
 riscv = { path = "../riscv", version = "0.15.0", features = ["rt"] }
-riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
+riscv-types = { path = "../riscv-types", version = "0.1.0" }
 riscv-rt-macros = { path = "macros", version = "0.6.0" }
 
 defmt = { version = "1.0.1", optional = true }

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -699,8 +699,8 @@ use riscv::register::{
     mtvec::{self as xtvec, Mtvec as Xtvec, TrapMode},
 };
 
-pub use riscv_pac::*;
 pub use riscv_rt_macros::{core_interrupt, entry, exception, external_interrupt};
+pub use riscv_types::*;
 
 #[cfg(feature = "post-init")]
 pub use riscv_rt_macros::post_init;

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -22,10 +22,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Bump MSRV to 1.81 due to `riscv-types`
+- Use `riscv-types` instead of `riscv-pac`
+- Reexport only `pac_enum` macro from `riscv-macros`
 - Fix broken links in register macro doc string.
 - Moved macros from `./macros/` to `../riscv-macros/`
 - Updated the license to `MIT or Apache-2.0`
-- Bump MSRV to 1.68 for latest version of syn 2.0
 - Now, `riscv::pac_enum` macro only includes trap-related code if `rt` or `rt-v-trap` features are enabled.
 
 ## [v0.15.0] - 2025-09-08

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -2,7 +2,7 @@
 name = "riscv"
 version = "0.15.0"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
@@ -29,6 +29,6 @@ rt-v-trap = ["rt", "riscv-macros/rt-v-trap"]
 [dependencies]
 critical-section = "1.2.0"
 embedded-hal = "1.0.0"
-riscv-pac = { path = "../riscv-pac", version = "0.2.0" }
+riscv-types = { path = "../riscv-types", version = "0.1.0" }
 riscv-macros = { path = "../riscv-macros", version = "0.3.0", optional = true }
 paste = "1.0.15"

--- a/riscv/README.md
+++ b/riscv/README.md
@@ -11,12 +11,12 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.61 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.81 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License
 
-Copyright 2019-2022 [RISC-V team][team]
+Copyright 2019-2025 [RISC-V team][team]
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice

--- a/riscv/src/interrupt.rs
+++ b/riscv/src/interrupt.rs
@@ -5,7 +5,7 @@
 use crate::result::Result;
 
 // re-export useful riscv-pac traits
-pub use riscv_pac::{CoreInterruptNumber, ExceptionNumber, InterruptNumber};
+pub use crate::{CoreInterruptNumber, ExceptionNumber, InterruptNumber};
 
 pub mod machine;
 pub mod supervisor;

--- a/riscv/src/interrupt/machine.rs
+++ b/riscv/src/interrupt/machine.rs
@@ -1,8 +1,6 @@
 use crate::{
     interrupt::Trap,
     register::{mcause, mepc, mie, mip, mstatus},
-};
-use riscv_pac::{
     result::{Error, Result},
     CoreInterruptNumber, ExceptionNumber, InterruptNumber,
 };

--- a/riscv/src/interrupt/supervisor.rs
+++ b/riscv/src/interrupt/supervisor.rs
@@ -1,8 +1,6 @@
 use crate::{
     interrupt::Trap,
     register::{scause, sepc, sie, sip, sstatus},
-};
-use riscv_pac::{
     result::{Error, Result},
     CoreInterruptNumber, ExceptionNumber, InterruptNumber,
 };

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -58,8 +58,8 @@ pub mod register;
 
 // Re-export crates of the RISC-V ecosystem
 #[cfg(feature = "riscv-macros")]
-pub use riscv_macros::*;
-pub use riscv_pac::*;
+pub use riscv_macros::pac_enum;
+pub use riscv_types::*;
 
 #[macro_use]
 mod macros;

--- a/riscv/src/register/mie.rs
+++ b/riscv/src/register/mie.rs
@@ -1,7 +1,9 @@
 //! mie register
 
-use crate::bits::{bf_extract, bf_insert};
-use riscv_pac::CoreInterruptNumber;
+use crate::{
+    bits::{bf_extract, bf_insert},
+    CoreInterruptNumber,
+};
 
 read_write_csr! {
     /// `mie` register

--- a/riscv/src/register/mip.rs
+++ b/riscv/src/register/mip.rs
@@ -1,7 +1,6 @@
 //! mip register
 
-use crate::bits::bf_extract;
-use riscv_pac::CoreInterruptNumber;
+use crate::{bits::bf_extract, CoreInterruptNumber};
 
 read_only_csr! {
     /// `mip` register

--- a/riscv/src/register/mvien.rs
+++ b/riscv/src/register/mvien.rs
@@ -1,8 +1,10 @@
 //! mvien register
 
-use crate::bits::{bf_extract, bf_insert};
-use riscv_pac::result::{Error, Result};
-use riscv_pac::InterruptNumber;
+use crate::{
+    bits::{bf_extract, bf_insert},
+    result::{Error, Result},
+    InterruptNumber,
+};
 
 #[cfg(target_arch = "riscv32")]
 const MASK: usize = 0xffff_e222;

--- a/riscv/src/register/mvienh.rs
+++ b/riscv/src/register/mvienh.rs
@@ -1,8 +1,10 @@
 //! mvienh register
 
-use crate::bits::{bf_extract, bf_insert};
-use riscv_pac::result::{Error, Result};
-use riscv_pac::InterruptNumber;
+use crate::{
+    bits::{bf_extract, bf_insert},
+    result::{Error, Result},
+    InterruptNumber,
+};
 
 read_write_csr! {
     /// `mvienh` register

--- a/riscv/src/register/scause.rs
+++ b/riscv/src/register/scause.rs
@@ -1,7 +1,6 @@
 //! scause register
 
-pub use crate::interrupt::Trap;
-pub use riscv_pac::{CoreInterruptNumber, ExceptionNumber, InterruptNumber}; // re-export useful riscv-pac traits
+pub use crate::{interrupt::Trap, CoreInterruptNumber, ExceptionNumber, InterruptNumber}; // re-export useful artifacts
 
 read_write_csr! {
     /// scause register

--- a/riscv/src/register/sie.rs
+++ b/riscv/src/register/sie.rs
@@ -1,7 +1,9 @@
 //! sie register
 
-use crate::bits::{bf_extract, bf_insert};
-use riscv_pac::CoreInterruptNumber;
+use crate::{
+    bits::{bf_extract, bf_insert},
+    CoreInterruptNumber,
+};
 
 read_write_csr! {
 /// sie register

--- a/riscv/src/register/sip.rs
+++ b/riscv/src/register/sip.rs
@@ -1,7 +1,6 @@
 //! sip register
 
-use crate::bits::bf_extract;
-use riscv_pac::CoreInterruptNumber;
+use crate::{bits::bf_extract, CoreInterruptNumber};
 
 read_only_csr! {
     /// sip register


### PR DESCRIPTION
This PR deprecates `riscv-pac` and uses `riscv-types` instead. As a result, we need to bump the MSRV of several crates to 1.81