### PR TITLE
Fix UB in heap init example docs

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix undefined behavior in heap initialization example documentation
 - Fix stack allocation algorithm for multi-core targets without M extension
 
 ## [v0.16.0] - 2025-09-08

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -279,7 +279,7 @@
 //! fn main() {
 //!     unsafe {
 //!         let heap_bottom = riscv_rt::heap_start() as usize;
-//!         let heap_size = &_heap_size as *const u8 as usize;
+//!         let heap_size = core::ptr::addr_of!(_heap_size) as usize;
 //!         some_allocator::initialize(heap_bottom, heap_size);
 //!     }
 //! }


### PR DESCRIPTION
`_heap_size` is not actually a valid address anywhere (of course we have to treat it as an address since it is a linker symbol), and therefore creating a reference to it, even as an intermediate step, is undefined behavior. It seems in debug mode rust will panic if we create a reference to null (e.g. if `_heap_size` is zero) even though we aren't attempting to access it.

This is just quick fix to replace that line with `addr_of!` which doesn't create an intermediate reference and therefore no longer UB. The macro is apparently now soft deprecated and suggests replacement with `&raw const` directly, but kept the macro for consistency with its other uses in code base.