### PR TITLE
Fix v-trap core interrupt macro

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix v-trap core interrupt so RISCV_RT_BASE_ISA must be defined
 - Fix undefined behavior in heap initialization example documentation
 - Fix stack allocation algorithm for multi-core targets without M extension
 

--- a/riscv-rt/macros/src/lib.rs
+++ b/riscv-rt/macros/src/lib.rs
@@ -783,6 +783,8 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 /// The argument of the macro must be a path to a variant of an enum that implements the `riscv_rt::CoreInterruptNumber` trait.
 ///
 /// If the `v-trap` feature is enabled, this macro generates the corresponding interrupt trap handler in assembly.
+/// This feature relies on the `RISCV_RT_BASE_ISA` environment variable being set to one of
+/// `rv32i`, `rv32e`, `rv64i`, or `rv64e`. Otherwise, this will **panic**.
 ///
 /// # Example
 ///
@@ -795,7 +797,7 @@ pub fn exception(args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn core_interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
     let arch = match () {
         #[cfg(feature = "v-trap")]
-        () => RiscvArch::try_from_env(),
+        () => Some(RiscvArch::try_from_env().expect("RISCV_RT_BASE_ISA must be defined")),
         #[cfg(not(feature = "v-trap"))]
         () => None,
     };


### PR DESCRIPTION
It turns out env variables set in build scripts only apply to their crate during compilation, and since the `core_interrupt` macro is likely called by other crates (e.g. by a HAL and by consumers of the HAL), it will not see `RISCV_RT_BASE_ISA` set by `riscv-rt`'s build script.

Thus, this macro will just silently omit the start_trap symbol for the defined interrupt leading to unexpected runtime behavior (trap pointing to DefaultHandler) if the consuming crate does not define this env variable itself before building. So I think it makes sense to panic during build to prevent this, would've saved me from losing a bit of sanity figuring out what was going on :P