### PR TITLE
Doucment riscv-rt features and fix minor doc issues

### DIFF
--- a/riscv-macros/CHANGELOG.md
+++ b/riscv-macros/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix `cargo doc` errors.
 - Use fully qualified paths in generated code (i.e., `::riscv` instead of `riscv`)
 - Moved from `riscv/macros/` to `riscv-macros/`
 - Now, `riscv::pac_enum` macro only includes trap-related code if `rt` or `rt-v-trap` features are enabled.

--- a/riscv-macros/src/lib.rs
+++ b/riscv-macros/src/lib.rs
@@ -426,7 +426,7 @@ core::arch::global_asm!("
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore,no_run
 /// use riscv::*;
 ///
 /// #[repr(usize)]

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Add features to documentation that were missing and fix `cargo doc` errors.
 - Update license to `MIT or Apache-2.0`
 - Fix clippy warnings in riscv_rt_macros::strip_type_path
 - Bump MSRV to 1.68 for latest syn 2.0 release

--- a/riscv-rt/src/lib.rs
+++ b/riscv-rt/src/lib.rs
@@ -156,7 +156,7 @@
 //!
 //! Our application would look like this:
 //!
-//! ```no_run
+//! ```ignore,no_run
 //! // src/main.rs
 //! #![no_main]
 //! #![no_std]
@@ -269,7 +269,7 @@
 //!
 //! ## Example
 //!
-//! ``` no_run
+//! ``` ignore,no_run
 //! extern crate some_allocator; // e.g., embedded_alloc::LlffHeap
 //!
 //! extern "C" {
@@ -357,7 +357,7 @@
 //!
 //! The following example shows how to implement the `_mp_hook` function in assembly.
 //!
-//! ``` no_run
+//! ``` ignore,no_run
 //! core::arch::global_asm!(
 //!     r#".section .init.mp_hook, "ax"
 //!     .global _mp_hook
@@ -433,7 +433,7 @@
 //!
 //! This function can be redefined in the following way:
 //!
-//! ``` no_run
+//! ``` ignore,no_run
 //! #[export_name = "ExceptionHandler"]
 //! fn custom_exception_handler(trap_frame: &riscv_rt::TrapFrame) -> ! {
 //!     // ...
@@ -542,7 +542,7 @@
 //!
 //! The following example shows how to implement the `__pre_init` function in assembly.
 //!
-//! ``` no_run
+//! ``` ignore,no_run
 //! core::arch::global_asm!(
 //!     r#".section .init.pre_init, "ax"
 //!     .global __pre_init
@@ -573,6 +573,20 @@
 //! ## `no-xtvec`
 //!
 //! Skips interrupts setup.
+//!
+//! ## `no-xie-xip`
+//!
+//! Skips disabling interrupts (to support chips without XIE/XIP CSRs).
+//!
+//! ## `no-interrupts`
+//!
+//! Opts out of the default implementation for `_dispatch_core_interrupt` to support platforms
+//! with custom core interrupt sources.
+//!
+//! ## `no-exceptions`
+//!
+//! Opts out of the default implementation for `_dispatch_exception` to support platforms
+//! with custom exception sources.
 //!
 //! ## `s-mode`
 //!
@@ -622,7 +636,7 @@
 //!
 //! ### Example
 //!
-//! ```rust,no_run
+//! ```rust,ignore,no_run
 //! core::arch::global_asm!(
 //! r#"
 //!     .section .trap.start, "ax"
@@ -639,6 +653,20 @@
 //! "#
 //! );
 //! ```
+//!
+//! ## `device`
+//!
+//! Automatically includes `device.x` (typically provided by PACs to provide weak aliases to interrupt handlers)
+//! in the linker script.
+//!
+//! ## `memory`
+//!
+//! Automatically includes [`memory.x`](#memoryx) (typically provided by BSPs) in the linker script.
+//!
+//! ## `defmt`
+//!
+//! Implements `defmt::Format` on certain types.
+//!
 //! [attr-entry]: attr.entry.html
 //! [attr-exception]: attr.exception.html
 //! [attr-external-interrupt]: attr.external_interrupt.html

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix broken links in register macro doc string.
 - Moved macros from `./macros/` to `../riscv-macros/`
 - Updated the license to `MIT or Apache-2.0`
 - Bump MSRV to 1.68 for latest version of syn 2.0

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -303,7 +303,7 @@ macro_rules! write_csr_as_usize_rv32 {
 
 /// Convenience macro to provide combined read/write of a CSR as a `usize`.
 ///
-/// This composes [`read_csr_as_usize`] and [`write_csr_as_usize`]. Use the
+/// This composes [read_csr_as_usize](crate::read_csr_as_usize) and [write_csr_as_usize](crate::write_csr_as_usize). Use the
 /// `safe` form to get safe wrappers instead of unsafe.
 #[macro_export]
 macro_rules! read_write_csr_as_usize {


### PR DESCRIPTION
This PR mainly documents `riscv-rt` features that were missing from the existing docs. Additionally, cleans up issues found via `cargo doc` and `cargo test --doc` by fixing a couple broken links and adding `ignore` to a few doc examples that can't actually compile.

Please let me know if you feel the wording for these features needs changing in the docs.