### PR TITLE
Prepare for release

### DIFF
--- a/riscv-macros/CHANGELOG.md
+++ b/riscv-macros/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.4.0 - 2025-12-19
+
 ### Added
 
 - New `rt` and `rt-v-trap` features to opt-in `riscv-rt`-related code in `riscv::pac_enum` macro.

--- a/riscv-macros/Cargo.toml
+++ b/riscv-macros/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["riscv", "register", "peripheral"]
 license = "MIT OR Apache-2.0"
 name = "riscv-macros"
 repository = "https://github.com/rust-embedded/riscv"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/riscv-pac/CHANGELOG.md
+++ b/riscv-pac/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## v0.3.0 - 2025-12-19
 
 ### Changed
 

--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.5.0 - 2025-12-19
+
 ### Changed
 
 - Bump MSRV to 1.81 due to `riscv`

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-peripheral"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embedded-hal = "1.0.0"
 paste = "1.0"
-riscv = { path = "../riscv", version = "0.15.0" }
+riscv = { path = "../riscv", version = "0.16.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.17.0 - 2025-12-19
+
 ### Added
 
 - Added examples for CI tests using semihosting and UART

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.16.0"
+version = "0.17.0"
 rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
@@ -24,16 +24,16 @@ targets = [
 riscv-target-parser = { path = "../riscv-target-parser", version = "0.1.2" }
 
 [dependencies]
-riscv = { path = "../riscv", version = "0.15.0", features = ["rt"] }
+riscv = { path = "../riscv", version = "0.16.0", features = ["rt"] }
 riscv-types = { path = "../riscv-types", version = "0.1.0" }
-riscv-rt-macros = { path = "macros", version = "0.6.0" }
+riscv-rt-macros = { path = "macros", version = "0.6.1" }
 
 defmt = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 panic-halt = "1.0.0"
 riscv-semihosting = { path = "../riscv-semihosting", version = "0.2.1" }
-riscv = { path = "../riscv", version = "0.15.0", features = ["critical-section-single-hart"] }
+riscv = { path = "../riscv", version = "0.16.0", features = ["critical-section-single-hart"] }
 
 [features]
 pre-init = []

--- a/riscv-rt/macros/Cargo.toml
+++ b/riscv-rt/macros/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["riscv", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "riscv-rt-macros"
 repository = "https://github.com/rust-embedded/riscv"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [lib]

--- a/riscv-types/CHANGELOG.md
+++ b/riscv-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.1.0 - 2025-12-19
+
 ### Changed
 
 - Bump MSRV to 1.81 due to `core::error::Error` trait

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.16.0 - 2025-12-19
+
 ### Added
 
 - Add `vstopi` CSR

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
@@ -30,5 +30,5 @@ rt-v-trap = ["rt", "riscv-macros/rt-v-trap"]
 critical-section = "1.2.0"
 embedded-hal = "1.0.0"
 riscv-types = { path = "../riscv-types", version = "0.1.0" }
-riscv-macros = { path = "../riscv-macros", version = "0.3.0", optional = true }
+riscv-macros = { path = "../riscv-macros", version = "0.4.0", optional = true }
 paste = "1.0.15"


### PR DESCRIPTION
This PR is ready for a new batch of releases in `crates.io`. @rmsyn @MabezDev could you check it out?

I am considering the MSRV bump to 1.81 as a breaking change, thus I am increasing the minor version of `riscv-peripheral` and `riscv-rt`. Let me know if you think we could leave it as a patch version.