### PR TITLE
Make ARCH_WIDTH byte aligned instead of bit aligned

### DIFF
--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.17.1 - 2026-01-13
+
+### Fixed
+
+- Fix `build.rs` so `ARCH_WIDTH` is passed to linker script in size of bytes (instead of bits)
+
 ## v0.17.0 - 2025-12-19
 
 ### Added

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.17.0"
+version = "0.17.1"
 rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]

--- a/riscv-rt/build.rs
+++ b/riscv-rt/build.rs
@@ -56,7 +56,8 @@ fn main() {
     let cargo_flags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
 
     if let Ok(target) = RiscvTarget::build(&target, &cargo_flags) {
-        let width = target.width();
+        // Linker script expects ARCH_WIDTH in bytes
+        let width_bytes = u32::from(target.width()) / 8;
 
         // set environment variable RISCV_RT_BASE_ISA to the base ISA of the target.
         println!(
@@ -86,6 +87,6 @@ fn main() {
                 println!("cargo:rustc-cfg={flag}");
             }
         }
-        add_linker_script(width.into()).unwrap();
+        add_linker_script(width_bytes).unwrap();
     }
 }


### PR DESCRIPTION
#385 pointed out the build script is passing `ARCH_WIDTH` in bits rather than bytes, so this PR simply divides width by 8 to correctly pass width in bytes. Does indeed seem to help reduce binary size slightly (the one example I tested it on reduced `.rodata` by 4 bytes).

Additionally bumps version to `0.17.1`.

Resolves #385 