### PR TITLE
Prepare for new release (riscv 0.16.1)

### DIFF
--- a/riscv-macros/CHANGELOG.md
+++ b/riscv-macros/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## v0.4.1 - Unreleased
+## Unreleased
+
+## v0.4.1 - 2026-05-29
 
 ### Added
 

--- a/riscv-peripheral/CHANGELOG.md
+++ b/riscv-peripheral/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## v0.5.1 - 2026-05-29
 
 ### Changed
+
 - replaced `paste` crate with `pastey` to fix RUSTSEC-2024-0436
 
 ## v0.5.0 - 2025-12-19

--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embedded-hal = "1.0.0"
 pastey = "0.2.2"
-riscv = { path = "../riscv", version = "0.16.0" }
+riscv = { path = "../riscv", version = "0.16.1" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/riscv-rt/CHANGELOG.md
+++ b/riscv-rt/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## v0.18.0 - Unreleased
+## v0.18.0 - 2026-05-29
 
 ### Added
 

--- a/riscv-rt/Cargo.toml
+++ b/riscv-rt/Cargo.toml
@@ -24,7 +24,7 @@ targets = [
 riscv-target-parser = { path = "../riscv-target-parser", version = "0.1.2" }
 
 [dependencies]
-riscv = { path = "../riscv", version = "0.16.0", features = ["rt"] }
+riscv = { path = "../riscv", version = "0.16.1", features = ["rt"] }
 riscv-types = { path = "../riscv-types", version = "0.1.0" }
 riscv-macros = { path = "../riscv-macros", version = "0.4.1", features = ["riscv-rt"] }
 
@@ -33,7 +33,7 @@ defmt = { version = "1.0.1", optional = true }
 [dev-dependencies]
 panic-halt = "1.0.0"
 riscv-semihosting = { path = "../riscv-semihosting", version = "0.2.1" }
-riscv = { path = "../riscv", version = "0.16.0", features = ["critical-section-single-hart"] }
+riscv = { path = "../riscv", version = "0.16.1", features = ["critical-section-single-hart"] }
 
 [features]
 pre-init = []

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## Unreleased
+
+## v0.16.1 - 2026-05-29
 
 ### Added
 
@@ -20,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Modify XS and SD bits to read-only summary fields instead of writable fields
 - replaced `paste` crate with `pastey` to fix RUSTSEC-2024-0436
 
-## v0.16.0 - 2025-12-19
+## v0.16.0 - 2025-12-19 (yanked)
 
 ### Added
 

--- a/riscv/Cargo.toml
+++ b/riscv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"
@@ -30,5 +30,5 @@ rt-v-trap = ["rt", "riscv-macros/rt-v-trap"]
 critical-section = "1.2.0"
 embedded-hal = "1.0.0"
 riscv-types = { path = "../riscv-types", version = "0.1.0" }
-riscv-macros = { path = "../riscv-macros", version = "0.4.0", optional = true }
+riscv-macros = { path = "../riscv-macros", version = "0.4.1", optional = true }
 pastey = "0.2.2"


### PR DESCRIPTION
This PR prepares the repo for a new release:

# Minor releases

- `riscv` v0.16.1
- `riscv-macros` v0.4.1
- `riscv-peripheral` v0.5.1

# Releases with breaking changes

- `riscv-rt` v0.18.0 (full riscv-macros migration, no pre_init macro)
- `riscv-rt-macros` v0.7.0 (deprecated in favor of `riscv-macros`)

@MabezDev can you check it?