### PR TITLE
minor fixes for releasing in crates.io

### DIFF
--- a/riscv-peripheral/Cargo.toml
+++ b/riscv-peripheral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-peripheral"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.81"
 repository = "https://github.com/rust-embedded/riscv"

--- a/riscv-rt/macros/Cargo.toml
+++ b/riscv-rt/macros/Cargo.toml
@@ -16,6 +16,8 @@ edition = "2021"
 [lib]
 proc-macro = true
 
+[workspace]
+
 [dependencies]
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
There were minor issues with `riscv-peripheral` and `riscv-rt-macros` that prevented me to publish them in `crates.io`.

@MabezDev could you do a quick check to unblock this?