### PR TITLE
Systematically define bit mask/offset/size for fields in CSRs

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   hand-computing the interrupt bit.
 - Add `UXL`/`SXL`/`SBE`/`MBE` `SHIFT`/`WIDTH`/`MASK` constants to `Mstatus`
   (RV64) for the fields implemented outside the field macros.
+- Add `BASE_SHIFT`/`BASE_MASK` constants to `Mtvec`/`Stvec` for the
+  trap-vector base address field (the `MODE` field consts come from the macros).
 
 ## v0.16.1 - 2026-05-29
 

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   constants on CSR types for every bitfield defined via the `read_write_csr_field!`
   and `read_only_csr_field!` macros, giving downstream code a single source of
   truth for compile-time bit positions and field-shifted masks.
+- Add `Mcause`/`Scause` `from_interrupt` and `from_exception` constructors to
+  build a cause value from a `CoreInterruptNumber`/`ExceptionNumber` without
+  hand-computing the interrupt bit.
 
 ## v0.16.1 - 2026-05-29
 

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Auto-generate `<FIELD>_SHIFT`, `<FIELD>_WIDTH`, and `<FIELD>_MASK` associated
+  constants on CSR types for every bitfield defined via the `read_write_csr_field!`
+  and `read_only_csr_field!` macros, giving downstream code a single source of
+  truth for compile-time bit positions and field-shifted masks.
+
 ## v0.16.1 - 2026-05-29
 
 ### Added

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `Mcause`/`Scause` `from_interrupt` and `from_exception` constructors to
   build a cause value from a `CoreInterruptNumber`/`ExceptionNumber` without
   hand-computing the interrupt bit.
+- Add `UXL`/`SXL`/`SBE`/`MBE` `SHIFT`/`WIDTH`/`MASK` constants to `Mstatus`
+  (RV64) for the fields implemented outside the field macros.
 
 ## v0.16.1 - 2026-05-29
 

--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   (RV64) for the fields implemented outside the field macros.
 - Add `BASE_SHIFT`/`BASE_MASK` constants to `Mtvec`/`Stvec` for the
   trap-vector base address field (the `MODE` field consts come from the macros).
+- Add `R`/`W`/`X`/`PERMISSION`/`A`/`L` byte-layout constants to `Pmp` for the
+  `pmpXcfg` configuration byte.
 
 ## v0.16.1 - 2026-05-29
 

--- a/riscv/src/register/macros.rs
+++ b/riscv/src/register/macros.rs
@@ -745,6 +745,48 @@ macro_rules! write_only_csr {
     };
 }
 
+/// Helper macro to emit `<FIELD>_SHIFT`, `<FIELD>_WIDTH`, and `<FIELD>_MASK`
+/// associated constants on a CSR type for a given bitfield.
+///
+/// - `<FIELD>_SHIFT`: the bit offset of the least-significant bit of the field.
+/// - `<FIELD>_WIDTH`: the number of bits in the field.
+/// - `<FIELD>_MASK`: the field-shifted bitmask (i.e. already shifted into
+///   position), suitable for masking a raw register value.
+///
+/// This is an implementation detail of the `*_csr_field!` macros and generally
+/// should not be called directly.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! csr_field_consts {
+    // single-bit field
+    ($ty:ident, $field:ident: $bit:literal) => {
+        $crate::paste! {
+            impl $ty {
+                #[doc = concat!("Bit shift of the `", stringify!($field), "` field.")]
+                pub const [<$field:upper _SHIFT>]: usize = $bit;
+                #[doc = concat!("Bit width of the `", stringify!($field), "` field.")]
+                pub const [<$field:upper _WIDTH>]: usize = 1;
+                #[doc = concat!("Field-shifted bitmask of the `", stringify!($field), "` field.")]
+                pub const [<$field:upper _MASK>]: usize = 1 << $bit;
+            }
+        }
+    };
+
+    // multi-bit field spanning bits `[start:end]` (inclusive)
+    ($ty:ident, $field:ident: [$start:literal : $end:literal]) => {
+        $crate::paste! {
+            impl $ty {
+                #[doc = concat!("Bit shift of the `", stringify!($field), "` field.")]
+                pub const [<$field:upper _SHIFT>]: usize = $start;
+                #[doc = concat!("Bit width of the `", stringify!($field), "` field.")]
+                pub const [<$field:upper _WIDTH>]: usize = $end - $start + 1;
+                #[doc = concat!("Field-shifted bitmask of the `", stringify!($field), "` field.")]
+                pub const [<$field:upper _MASK>]: usize = ((1 << ($end - $start + 1)) - 1) << $start;
+            }
+        }
+    };
+}
+
 /// Defines field accessor functions for a read-write CSR type.
 #[macro_export]
 macro_rules! read_write_csr_field {
@@ -836,6 +878,8 @@ macro_rules! read_only_csr_field {
      $field:ident: $bit:literal$(,)?) => {
         const _: () = assert!($bit < usize::BITS);
 
+        $crate::csr_field_consts!($ty, $field: $bit);
+
         impl $ty {
             $(#[$field_doc])+
             #[inline]
@@ -850,6 +894,8 @@ macro_rules! read_only_csr_field {
      $field:ident: $bit_start:literal..=$bit_end:literal$(,)?) => {
         const _: () = assert!($bit_end < usize::BITS);
         const _: () = assert!($bit_start < $bit_end);
+
+        $crate::csr_field_consts!($ty, $field: [$bit_start : $bit_end]);
 
         $crate::paste! {
             impl $ty {
@@ -882,6 +928,8 @@ macro_rules! read_only_csr_field {
         const _: () = assert!($bit_end < usize::BITS);
         const _: () = assert!($bit_start < $bit_end);
 
+        $crate::csr_field_consts!($ty, $field: [$bit_start : $bit_end]);
+
         impl $ty {
             $(#[$field_doc])+
             #[inline]
@@ -898,6 +946,8 @@ macro_rules! read_only_csr_field {
     ) => {
         const _: () = assert!($field_end < usize::BITS);
         const _: () = assert!($field_start <= $field_end);
+
+        $crate::csr_field_consts!($ty, $field: [$field_start : $field_end]);
 
         $crate::paste! {
             impl $ty {

--- a/riscv/src/register/mcause.rs
+++ b/riscv/src/register/mcause.rs
@@ -1,6 +1,7 @@
 //! mcause register
 
 pub use crate::interrupt::Trap;
+use crate::{CoreInterruptNumber, ExceptionNumber};
 
 read_only_csr! {
     /// `mcause` register
@@ -37,6 +38,24 @@ read_only_csr_field! {
 }
 
 impl Mcause {
+    /// Creates an `Mcause` value representing the given core interrupt source.
+    ///
+    /// The [interrupt bit](Self::IS_INTERRUPT_MASK) is set and the `code` field
+    /// is set to the interrupt number.
+    #[inline]
+    pub fn from_interrupt<I: CoreInterruptNumber>(interrupt: I) -> Self {
+        Self::from_bits(Self::IS_INTERRUPT_MASK | interrupt.number())
+    }
+
+    /// Creates an `Mcause` value representing the given exception source.
+    ///
+    /// The interrupt bit is clear and the `code` field is set to the exception
+    /// number.
+    #[inline]
+    pub fn from_exception<E: ExceptionNumber>(exception: E) -> Self {
+        Self::from_bits(exception.number())
+    }
+
     /// Returns the trap cause represented by this register.
     ///
     /// # Note
@@ -56,5 +75,29 @@ impl Mcause {
     #[inline]
     pub fn is_exception(&self) -> bool {
         !self.is_interrupt()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interrupt::machine::{Exception, Interrupt};
+
+    #[test]
+    fn test_mcause() {
+        let m = Mcause::from_interrupt(Interrupt::MachineExternal);
+        assert!(m.is_interrupt());
+        assert!(!m.is_exception());
+        assert_eq!(m.code(), Interrupt::MachineExternal as usize);
+        assert_eq!(
+            m.cause(),
+            Trap::Interrupt(Interrupt::MachineExternal as usize)
+        );
+
+        let m = Mcause::from_exception(Exception::Breakpoint);
+        assert!(m.is_exception());
+        assert!(!m.is_interrupt());
+        assert_eq!(m.code(), Exception::Breakpoint as usize);
+        assert_eq!(m.cause(), Trap::Exception(Exception::Breakpoint as usize));
     }
 }

--- a/riscv/src/register/mstatus.rs
+++ b/riscv/src/register/mstatus.rs
@@ -352,6 +352,42 @@ impl Mstatus {
     }
 }
 
+/// Bitfield constants for the `mstatus` fields that are implemented manually
+/// (rather than via the field macros) because they only exist on 64-bit targets.
+///
+/// These complement the macro-generated `<FIELD>_SHIFT`/`_WIDTH`/`_MASK`
+/// constants for the remaining `mstatus` fields.
+#[cfg(not(target_arch = "riscv32"))]
+impl Mstatus {
+    /// Bit shift of the `uxl` (U-mode XLEN) field.
+    pub const UXL_SHIFT: usize = 32;
+    /// Bit width of the `uxl` field.
+    pub const UXL_WIDTH: usize = 2;
+    /// Field-shifted bitmask of the `uxl` field.
+    pub const UXL_MASK: usize = ((1 << Self::UXL_WIDTH) - 1) << Self::UXL_SHIFT;
+
+    /// Bit shift of the `sxl` (S-mode XLEN) field.
+    pub const SXL_SHIFT: usize = 34;
+    /// Bit width of the `sxl` field.
+    pub const SXL_WIDTH: usize = 2;
+    /// Field-shifted bitmask of the `sxl` field.
+    pub const SXL_MASK: usize = ((1 << Self::SXL_WIDTH) - 1) << Self::SXL_SHIFT;
+
+    /// Bit shift of the `sbe` (S-mode endianness) field.
+    pub const SBE_SHIFT: usize = 36;
+    /// Bit width of the `sbe` field.
+    pub const SBE_WIDTH: usize = 1;
+    /// Field-shifted bitmask of the `sbe` field.
+    pub const SBE_MASK: usize = ((1 << Self::SBE_WIDTH) - 1) << Self::SBE_SHIFT;
+
+    /// Bit shift of the `mbe` (M-mode endianness) field.
+    pub const MBE_SHIFT: usize = 37;
+    /// Bit width of the `mbe` field.
+    pub const MBE_WIDTH: usize = 1;
+    /// Field-shifted bitmask of the `mbe` field.
+    pub const MBE_MASK: usize = ((1 << Self::MBE_WIDTH) - 1) << Self::MBE_SHIFT;
+}
+
 set!(0x300);
 clear!(0x300);
 

--- a/riscv/src/register/mtvec.rs
+++ b/riscv/src/register/mtvec.rs
@@ -83,6 +83,17 @@ impl Mtvec {
     }
 }
 
+impl Mtvec {
+    /// Bit shift of the trap-vector base address (`BASE`) field.
+    ///
+    /// The `MODE` field consts (`TRAP_MODE_SHIFT`/`TRAP_MODE_WIDTH`/
+    /// `TRAP_MODE_MASK`) are generated from the [`trap_mode`](Self::trap_mode)
+    /// field.
+    pub const BASE_SHIFT: usize = 2;
+    /// Field-shifted bitmask of the trap-vector base address (`BASE`) field.
+    pub const BASE_MASK: usize = !((1 << Self::BASE_SHIFT) - 1);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/riscv/src/register/pmpcfgx.rs
+++ b/riscv/src/register/pmpcfgx.rs
@@ -57,6 +57,42 @@ pub struct Pmp {
     pub locked: bool,
 }
 
+impl Pmp {
+    /// Bit shift of the `R` (read) permission within a `pmpXcfg` byte.
+    pub const R_SHIFT: usize = 0;
+    /// Field-shifted bitmask of the `R` (read) permission.
+    pub const R_MASK: u8 = 1 << Self::R_SHIFT;
+
+    /// Bit shift of the `W` (write) permission within a `pmpXcfg` byte.
+    pub const W_SHIFT: usize = 1;
+    /// Field-shifted bitmask of the `W` (write) permission.
+    pub const W_MASK: u8 = 1 << Self::W_SHIFT;
+
+    /// Bit shift of the `X` (execute) permission within a `pmpXcfg` byte.
+    pub const X_SHIFT: usize = 2;
+    /// Field-shifted bitmask of the `X` (execute) permission.
+    pub const X_MASK: u8 = 1 << Self::X_SHIFT;
+
+    /// Bit shift of the `R`/`W`/`X` permission ([`Permission`]) sub-field.
+    pub const PERMISSION_SHIFT: usize = 0;
+    /// Bit width of the permission sub-field.
+    pub const PERMISSION_WIDTH: usize = 3;
+    /// Field-shifted bitmask of the permission sub-field.
+    pub const PERMISSION_MASK: u8 = ((1 << Self::PERMISSION_WIDTH) - 1) << Self::PERMISSION_SHIFT;
+
+    /// Bit shift of the `A` (address-matching mode, [`Range`]) field.
+    pub const A_SHIFT: usize = 3;
+    /// Bit width of the `A` field.
+    pub const A_WIDTH: usize = 2;
+    /// Field-shifted bitmask of the `A` field.
+    pub const A_MASK: u8 = ((1 << Self::A_WIDTH) - 1) << Self::A_SHIFT;
+
+    /// Bit shift of the `L` (locked) field within a `pmpXcfg` byte.
+    pub const L_SHIFT: usize = 7;
+    /// Field-shifted bitmask of the `L` (locked) field.
+    pub const L_MASK: u8 = 1 << Self::L_SHIFT;
+}
+
 pub struct Pmpcsr {
     /// Holds the raw contents of a PMP CSR Register
     pub bits: usize,
@@ -306,4 +342,21 @@ pub mod pmpcfg15 {
 
     set_pmp!();
     clear_pmp!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pmp() {
+        // The byte-layout consts must agree with the field positions used by the
+        // `try_into_config` decoder: permission in bits [2:0], addressing mode (A)
+        // in [4:3], lock (L) in bit 7.
+        let byte: u8 =
+            Pmp::R_MASK | Pmp::X_MASK | ((Range::NAPOT as u8) << Pmp::A_SHIFT) | Pmp::L_MASK;
+        assert_eq!(byte & Pmp::PERMISSION_MASK, Permission::RX as u8);
+        assert_eq!((byte & Pmp::A_MASK) >> Pmp::A_SHIFT, Range::NAPOT as u8);
+        assert_ne!(byte & Pmp::L_MASK, 0);
+    }
 }

--- a/riscv/src/register/scause.rs
+++ b/riscv/src/register/scause.rs
@@ -43,6 +43,24 @@ read_write_csr_field! {
 }
 
 impl Scause {
+    /// Creates an `Scause` value representing the given core interrupt source.
+    ///
+    /// The [interrupt bit](Self::INTERRUPT_MASK) is set and the `code` field is
+    /// set to the interrupt number.
+    #[inline]
+    pub fn from_interrupt<I: CoreInterruptNumber>(interrupt: I) -> Self {
+        Self::from_bits(Self::INTERRUPT_MASK | interrupt.number())
+    }
+
+    /// Creates an `Scause` value representing the given exception source.
+    ///
+    /// The interrupt bit is clear and the `code` field is set to the exception
+    /// number.
+    #[inline]
+    pub fn from_exception<E: ExceptionNumber>(exception: E) -> Self {
+        Self::from_bits(exception.number())
+    }
+
     /// Returns the trap cause represented by this register.
     ///
     /// # Note
@@ -86,6 +104,7 @@ pub unsafe fn set<I: CoreInterruptNumber, E: ExceptionNumber>(cause: Trap<I, E>)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interrupt::machine::{Exception, Interrupt};
 
     #[test]
     fn test_scause() {
@@ -135,5 +154,16 @@ mod tests {
                 assert_eq!(scause.code(), exp_code);
                 assert_eq!(scause.cause(), exp_cause);
             });
+
+        // check the `from_interrupt`/`from_exception` constructors.
+        let s = Scause::from_interrupt(Interrupt::SupervisorExternal);
+        assert!(s.is_interrupt());
+        assert!(!s.is_exception());
+        assert_eq!(s.code(), Interrupt::SupervisorExternal as usize);
+
+        let s = Scause::from_exception(Exception::Breakpoint);
+        assert!(s.is_exception());
+        assert!(!s.is_interrupt());
+        assert_eq!(s.code(), Exception::Breakpoint as usize);
     }
 }

--- a/riscv/src/register/stvec.rs
+++ b/riscv/src/register/stvec.rs
@@ -74,6 +74,17 @@ impl Stvec {
     }
 }
 
+impl Stvec {
+    /// Bit shift of the trap-vector base address (`BASE`) field.
+    ///
+    /// The `MODE` field consts (`TRAP_MODE_SHIFT`/`TRAP_MODE_WIDTH`/
+    /// `TRAP_MODE_MASK`) are generated from the [`trap_mode`](Self::trap_mode)
+    /// field.
+    pub const BASE_SHIFT: usize = 2;
+    /// Field-shifted bitmask of the trap-vector base address (`BASE`) field.
+    pub const BASE_MASK: usize = !((1 << Self::BASE_SHIFT) - 1);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/riscv/src/register/tests/read_only_csr.rs
+++ b/riscv/src/register/tests/read_only_csr.rs
@@ -117,4 +117,27 @@ fn test_mtest_read_only() {
     // check that setting an invalid variant returns `None`
     mtest = Mtest::from_bits(0xbad << 8);
     assert_eq!(mtest.try_field_enum(), Err(Error::InvalidVariant(13)),);
+
+    // the macro must generate consts satisfying MASK == ((1 << WIDTH) - 1) << SHIFT
+    // for every field shape (single-bit, range, multi-bit, enum).
+    for (shift, width, mask) in [
+        (Mtest::SINGLE_SHIFT, Mtest::SINGLE_WIDTH, Mtest::SINGLE_MASK),
+        (
+            Mtest::MULTI_RANGE_SHIFT,
+            Mtest::MULTI_RANGE_WIDTH,
+            Mtest::MULTI_RANGE_MASK,
+        ),
+        (
+            Mtest::MULTI_FIELD_SHIFT,
+            Mtest::MULTI_FIELD_WIDTH,
+            Mtest::MULTI_FIELD_MASK,
+        ),
+        (
+            Mtest::FIELD_ENUM_SHIFT,
+            Mtest::FIELD_ENUM_WIDTH,
+            Mtest::FIELD_ENUM_MASK,
+        ),
+    ] {
+        assert_eq!(mask, ((1 << width) - 1) << shift);
+    }
 }

--- a/riscv/src/register/tests/read_write_csr.rs
+++ b/riscv/src/register/tests/read_write_csr.rs
@@ -125,4 +125,27 @@ fn test_mtest_read_write() {
     // check that setting an invalid variant returns `None`
     mtest = Mtest::from_bits(0xbad << 8);
     assert_eq!(mtest.try_field_enum(), Err(Error::InvalidVariant(13)));
+
+    // the macro must generate consts satisfying MASK == ((1 << WIDTH) - 1) << SHIFT
+    // for every field shape (single-bit, range, multi-bit, enum).
+    for (shift, width, mask) in [
+        (Mtest::SINGLE_SHIFT, Mtest::SINGLE_WIDTH, Mtest::SINGLE_MASK),
+        (
+            Mtest::MULTI_RANGE_SHIFT,
+            Mtest::MULTI_RANGE_WIDTH,
+            Mtest::MULTI_RANGE_MASK,
+        ),
+        (
+            Mtest::MULTI_FIELD_SHIFT,
+            Mtest::MULTI_FIELD_WIDTH,
+            Mtest::MULTI_FIELD_MASK,
+        ),
+        (
+            Mtest::FIELD_ENUM_SHIFT,
+            Mtest::FIELD_ENUM_WIDTH,
+            Mtest::FIELD_ENUM_MASK,
+        ),
+    ] {
+        assert_eq!(mask, ((1 << width) - 1) << shift);
+    }
 }


### PR DESCRIPTION
This PR systematically adds associated constants for each bitfield in the CSRs. Most of the heavy
lifting was done by extending the existing bitfield definition macros (read_only_csr_field! /
read_write_csr_field!), but there were also specific additions for:
- mstatus/sstatus:  UXL, SXL, SBE, MBE (RV64 fields implemented outside the macros)
- mtvec/stvec:  BASE_SHIFT/BASE_MASK (the MODE field is already macro-generated via TRAP_MODE_*)
- pmpcfg:  R/W/X/PERMISSION/A/L byte-layout constants on the Pmp type (PMP uses enums, not the field
   macros)

These are just new definitions, so no changes to existing APIs. It's primarily to make these constants available to inline asm.