### PR TITLE
riscv: add stopei and vstopei AIA CSRs

### DIFF
--- a/riscv/CHANGELOG.md
+++ b/riscv/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `stopei` and `vstopei` CSRs (AIA supervisor/virtual-supervisor top external
+  interrupt), completing the `*topei` set alongside `mtopei`.
 - Auto-generate `<FIELD>_SHIFT`, `<FIELD>_WIDTH`, and `<FIELD>_MASK` associated
   constants on CSR types for every bitfield defined via the `read_write_csr_field!`
   and `read_only_csr_field!` macros, giving downstream code a single source of

--- a/riscv/src/register.rs
+++ b/riscv/src/register.rs
@@ -62,8 +62,10 @@ pub mod senvcfg;
 pub mod sepc;
 pub mod sip;
 pub mod sscratch;
+pub mod stopei;
 pub mod stopi;
 pub mod stval;
+pub mod vstopei;
 pub mod vstopi;
 
 // Supervisor Protection and Translation

--- a/riscv/src/register/stopei.rs
+++ b/riscv/src/register/stopei.rs
@@ -1,0 +1,70 @@
+//! `stopei` register — Supervisor Top External Interrupt (0x15C)
+//!
+//! This CSR is part of the RISC-V Advanced Interrupt Architecture (AIA). It reports the
+//! highest-priority pending-and-enabled interrupt from the IMSIC supervisor-level interrupt file.
+//! The interrupt identity is in bits 26:16 and the interrupt priority (same value) in bits 10:0.
+
+read_write_csr! {
+    /// Supervisor Top External Interrupt Register
+    Stopei: 0x15C,
+    mask: 0x07FF_07FF,
+}
+
+read_write_csr_field! {
+    Stopei,
+    /// Interrupt ID (bits 16..26)
+    ///
+    /// Identifies the specific interrupt source. A value of 0 indicates no interrupt is pending.
+    iid: [16:26],
+}
+
+read_write_csr_field! {
+    Stopei,
+    /// Interrupt Priority ID (bits 0..10)
+    ///
+    /// Represents the priority level of the pending interrupt.
+    /// Lower numerical values indicate higher priority interrupts.
+    iprio: [0:10],
+}
+
+impl Stopei {
+    /// Returns true if there is a valid interrupt pending.
+    #[inline]
+    pub fn is_interrupt_pending(&self) -> bool {
+        self.iid() != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stopei_fields() {
+        let mut stopei = Stopei::from_bits(0);
+        test_csr_field!(stopei, iid: [16, 26], 0x0);
+        test_csr_field!(stopei, iprio: [0, 10], 0x0);
+
+        let mut stopei = Stopei::from_bits((0xB << 16) | 5);
+        test_csr_field!(stopei, iid: [16, 26], 0xB);
+        test_csr_field!(stopei, iprio: [0, 10], 0x5);
+
+        let mut stopei = Stopei::from_bits((0x7FF << 16) | 0x7FF);
+        test_csr_field!(stopei, iid: [16, 26], 0x7FF);
+        test_csr_field!(stopei, iprio: [0, 10], 0x7FF);
+
+        let mut stopei = Stopei::from_bits(1 << 16);
+        test_csr_field!(stopei, iid: [16, 26], 0x1);
+        test_csr_field!(stopei, iprio: [0, 10], 0x0);
+
+        let mut stopei = Stopei::from_bits(1);
+        test_csr_field!(stopei, iid: [16, 26], 0x0);
+        test_csr_field!(stopei, iprio: [0, 10], 0x1);
+    }
+
+    #[test]
+    fn test_stopei_bitmask() {
+        let stopei = Stopei::from_bits(usize::MAX);
+        assert_eq!(stopei.bits(), 0x07FF_07FFusize);
+    }
+}

--- a/riscv/src/register/vstopei.rs
+++ b/riscv/src/register/vstopei.rs
@@ -1,0 +1,70 @@
+//! `vstopei` register — Virtual Supervisor Top External Interrupt (0x25C)
+//!
+//! This CSR is part of the RISC-V Advanced Interrupt Architecture (AIA). It reports the
+//! highest-priority pending-and-enabled interrupt from the IMSIC guest interrupt file.
+//! The interrupt identity is in bits 26:16 and the interrupt priority (same value) in bits 10:0.
+
+read_write_csr! {
+    /// Virtual Supervisor Top External Interrupt Register
+    Vstopei: 0x25C,
+    mask: 0x07FF_07FF,
+}
+
+read_write_csr_field! {
+    Vstopei,
+    /// Interrupt ID (bits 16..26)
+    ///
+    /// Identifies the specific interrupt source. A value of 0 indicates no interrupt is pending.
+    iid: [16:26],
+}
+
+read_write_csr_field! {
+    Vstopei,
+    /// Interrupt Priority ID (bits 0..10)
+    ///
+    /// Represents the priority level of the pending interrupt.
+    /// Lower numerical values indicate higher priority interrupts.
+    iprio: [0:10],
+}
+
+impl Vstopei {
+    /// Returns true if there is a valid interrupt pending.
+    #[inline]
+    pub fn is_interrupt_pending(&self) -> bool {
+        self.iid() != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vstopei_fields() {
+        let mut vstopei = Vstopei::from_bits(0);
+        test_csr_field!(vstopei, iid: [16, 26], 0x0);
+        test_csr_field!(vstopei, iprio: [0, 10], 0x0);
+
+        let mut vstopei = Vstopei::from_bits((0xB << 16) | 5);
+        test_csr_field!(vstopei, iid: [16, 26], 0xB);
+        test_csr_field!(vstopei, iprio: [0, 10], 0x5);
+
+        let mut vstopei = Vstopei::from_bits((0x7FF << 16) | 0x7FF);
+        test_csr_field!(vstopei, iid: [16, 26], 0x7FF);
+        test_csr_field!(vstopei, iprio: [0, 10], 0x7FF);
+
+        let mut vstopei = Vstopei::from_bits(1 << 16);
+        test_csr_field!(vstopei, iid: [16, 26], 0x1);
+        test_csr_field!(vstopei, iprio: [0, 10], 0x0);
+
+        let mut vstopei = Vstopei::from_bits(1);
+        test_csr_field!(vstopei, iid: [16, 26], 0x0);
+        test_csr_field!(vstopei, iprio: [0, 10], 0x1);
+    }
+
+    #[test]
+    fn test_vstopei_bitmask() {
+        let vstopei = Vstopei::from_bits(usize::MAX);
+        assert_eq!(vstopei.bits(), 0x07FF_07FFusize);
+    }
+}


### PR DESCRIPTION

  Adds the supervisor (`stopei`, 0x15C) and virtual-supervisor (`vstopei`,
  0x25C) top external interrupt registers, completing the `*topei` set
  alongside `mtopei` (#400).
  
  Both mirror the `mtopei` layout — `iid [16:26]`, `iprio [0:10]`, mask
  `0x07FF_07FF`, with an `is_interrupt_pending()` helper and field/bitmask
  tests. Follows on from #394 (siselect/vsiselect/stopi).

  - `cargo test -p riscv`: 60 passed (incl. new stopei/vstopei tests)
  - builds clean for `riscv32imac-unknown-none-elf`
  - fmt + clippy clean
